### PR TITLE
project: basic player actions (make money, win the game)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -9,6 +9,64 @@ Chosen product rules for this plan:
 - Current selections are private to the current player only.
 - Winning must persist the winner.
 
+## Implementation Phases
+### Phase 1: Data model and backend primitives
+1. Add `winnerPlayerId` to `games` and add the append-only `game_player_actions` table keyed by `(gameId, playerId, tick)`.
+2. Update Drizzle schema, inferred row types, and migration files for both schema changes.
+3. Add backend action constants and types for:
+   - action ids
+   - action cost/reward rules
+   - shared Zod schema for API output
+4. Add repository methods to:
+   - upsert one action for `(gameId, playerId, tick)`
+   - fetch one action for `(gameId, playerId, tick)`
+   - fetch all actions for `(gameId, tick)`
+
+### Phase 2: API and business rules
+1. Add a `gamePlayerActions` controller following the existing controller pattern.
+2. In action submission, resolve the game’s current tick from `game_states`.
+3. Enforce submission rules:
+   - game exists
+   - game is started
+   - game is not ended
+   - player belongs to the game
+   - player can afford the selected action now
+4. Add tRPC routes:
+   - `getCurrent({ gameId })`
+   - `setCurrent({ gameId, actionType })`
+5. Register the router in `createApi.ts` and expose any required frontend API types.
+
+### Phase 3: Tick resolution
+1. Extend tick processing to fetch all actions for `(gameId, gameState.tick)` before resolving players.
+2. Keep the existing passive `+1 money` income.
+3. Resolve submitted actions for that tick:
+   - `MAKE_MORE_MONEY`: `-2 money`, then `+5 money`
+   - `WIN_THE_GAME`: `-10 money`, set `endedAt`, set `winnerPlayerId`
+4. If a player wins:
+   - finish the current tick
+   - do not schedule the next tick
+   - leave existing action rows untouched
+5. If no player wins:
+   - schedule the next tick as today
+   - update `game_states` to the next tick
+   - leave existing action rows untouched
+
+### Phase 4: Frontend play screen
+1. Extend `/play/$gameId` to fetch both the player game state and the current action for the current tick.
+2. Add a basic action selection UI with two choices:
+   - `Make More Money`
+   - `Win The Game`
+3. Show the currently selected action and its cost/effect.
+4. Disable unavailable actions when the player lacks money and show an inline reason.
+5. Submit selection changes through the new mutation and refresh the current-action query so refreshes remain consistent.
+6. After tick advancement, show no current selection for the new tick until the player picks again.
+
+### Phase 5: Verification
+1. Run repository-level checks for append-only per-tick action behavior.
+2. Run controller/router checks for membership, game lifecycle, and affordability rules.
+3. Run tick-processing checks for normal income, action resolution, and win handling.
+4. Run frontend manual verification on refresh persistence, selection changes, and post-tick empty state.
+
 ## Implementation Changes
 ### Data model
 - Add a new `game_player_actions` table keyed by `(gameId, playerId, tick)` with:
@@ -24,6 +82,7 @@ Chosen product rules for this plan:
   - `MAKE_MORE_MONEY`: cost `2 MONEY`, reward `5 MONEY`
   - `WIN_THE_GAME`: cost `10 MONEY`, ends the game, no resource reward
 - Generate a migration for both schema changes and update Drizzle schema/types accordingly.
+- Add a uniqueness guarantee via the primary key so each player has at most one action row per game tick.
 
 ### Backend API and business logic
 - Add a dedicated player-actions backend slice following the existing router/controller/repository pattern.
@@ -74,6 +133,61 @@ Chosen product rules for this plan:
 - After a tick processes and actions are reset, the page should show no selected action on the next successful refetch.
 - After a tick processes, the page should show no selected action for the new current tick unless the player chooses another one.
 - If winner persistence is surfaced in existing game summary/status views, show ended state consistently; winner display on the frontend can be limited to the play page or deferred unless already needed by the changed screens.
+
+## Detailed Steps
+### Step 1: Schema and types
+- Add `winnerPlayerId` to `gamesTable` with a nullable FK to `playersTable`.
+- Add `gamePlayerActionsTable` with `gameId`, `playerId`, `tick`, `actionType`, `createdAt`, and `updatedAt`.
+- Use FK constraints back to the game/player membership shape so action rows stay tied to valid game participants.
+- Update generated migration artifacts and any inferred repository row types.
+
+### Step 2: Action domain model
+- Add a backend module for player action constants using the repo’s `as const` pattern.
+- Define the supported action ids and their cost/effect metadata in one place.
+- Add a Zod schema and exported type for `GamePlayerAction`.
+
+### Step 3: Repository layer
+- Create a `GamePlayerActionsRepository`.
+- Implement upsert-by-primary-key for `(gameId, playerId, tick)`.
+- Implement `getByGameIdPlayerIdAndTick`.
+- Implement `getByGameIdAndTick`.
+- Keep all DB access isolated in this repository.
+
+### Step 4: Controller layer
+- Create a `GamePlayerActionsController`.
+- On `setCurrent`, fetch the player’s current game state to obtain the active tick and current money.
+- Reject writes when the game state does not exist, the player is not in the game, the game has ended, or the action is unaffordable.
+- Return the persisted action row mapped to the API schema.
+- On `getCurrent`, read the current tick first and then fetch the action for that tick only.
+
+### Step 5: Router integration
+- Add `gamePlayerActions.router.ts`.
+- Add private procedures for `getCurrent` and `setCurrent`.
+- Keep the same DI and return-type pattern as the existing routers.
+- Register the new router namespace in `createApi.ts`.
+- Export any frontend-consumed output types if needed.
+
+### Step 6: Tick-processing integration
+- Inject `GamePlayerActionsRepository` into the tick-processing entrypoint and `processTick`.
+- For each game tick being processed, fetch actions by `(gameId, gameState.tick)` once before looping players.
+- Match actions to players during resolution.
+- Preserve the current money increment behavior.
+- Apply action effects after the passive income.
+- On `WIN_THE_GAME`, persist `endedAt` and `winnerPlayerId`, skip next-tick creation, and finish the current tick cleanly.
+- Do not delete or mutate historical action rows once the tick is processed.
+
+### Step 7: Frontend integration
+- Add frontend usage of the new router methods in `play.$gameId.tsx`.
+- Query the current action alongside the existing game-state query.
+- Render a minimal action menu with clear selected/unselected states.
+- Use a mutation to change the current action and refetch the current-action query on success.
+- Keep the UI resilient when no action exists for the current tick.
+
+### Step 8: Verification pass
+- Validate append-only DB behavior for multiple ticks.
+- Validate that changing the action before processing overwrites only the current tick row.
+- Validate that advancing the tick results in no selected action for the new tick.
+- Validate that winning ends the game and persists the winner.
 
 ## Public Interfaces / Types
 - New backend action type enum-like constant and Zod schema for `GamePlayerAction`.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,16 +1,20 @@
 # Player Actions V1
 
 ## Summary
+
 Add per-player, per-game action selection for active games with two actions: `MAKE_MORE_MONEY` and `WIN_THE_GAME`. Players choose at most one action for the upcoming tick from the play screen, can change it any time before processing starts, and their current selection persists across page refreshes. Tick processing resolves the selected action for the current tick without deleting historical action rows.
 
 Chosen product rules for this plan:
+
 - Ticks keep the existing passive `+1 money`.
 - Action submission is rejected unless the player can already afford the action at submit time.
 - Current selections are private to the current player only.
 - Winning must persist the winner.
 
 ## Implementation Phases
+
 ### Phase 1: Data model and backend primitives
+
 1. Add `winnerPlayerId` to `games` and add the append-only `game_player_actions` table keyed by `(gameId, playerId, tick)`.
 2. Update Drizzle schema, inferred row types, and migration files for both schema changes.
 3. Add backend action constants and types for:
@@ -23,6 +27,7 @@ Chosen product rules for this plan:
    - fetch all actions for `(gameId, tick)`
 
 ### Phase 2: API and business rules
+
 1. Add a `gamePlayerActions` controller following the existing controller pattern.
 2. In action submission, resolve the game’s current tick from `game_states`.
 3. Enforce submission rules:
@@ -37,6 +42,7 @@ Chosen product rules for this plan:
 5. Register the router in `createApi.ts` and expose any required frontend API types.
 
 ### Phase 3: Tick resolution
+
 1. Extend tick processing to fetch all actions for `(gameId, gameState.tick)` before resolving players.
 2. Keep the existing passive `+1 money` income.
 3. Resolve submitted actions for that tick:
@@ -52,6 +58,7 @@ Chosen product rules for this plan:
    - leave existing action rows untouched
 
 ### Phase 4: Frontend play screen
+
 1. Extend `/play/$gameId` to fetch both the player game state and the current action for the current tick.
 2. Add a basic action selection UI with two choices:
    - `Make More Money`
@@ -62,13 +69,16 @@ Chosen product rules for this plan:
 6. After tick advancement, show no current selection for the new tick until the player picks again.
 
 ### Phase 5: Verification
+
 1. Run repository-level checks for append-only per-tick action behavior.
 2. Run controller/router checks for membership, game lifecycle, and affordability rules.
 3. Run tick-processing checks for normal income, action resolution, and win handling.
 4. Run frontend manual verification on refresh persistence, selection changes, and post-tick empty state.
 
 ## Implementation Changes
+
 ### Data model
+
 - Add a new `game_player_actions` table keyed by `(gameId, playerId, tick)` with:
   - `gameId`
   - `playerId`
@@ -85,6 +95,7 @@ Chosen product rules for this plan:
 - Add a uniqueness guarantee via the primary key so each player has at most one action row per game tick.
 
 ### Backend API and business logic
+
 - Add a dedicated player-actions backend slice following the existing router/controller/repository pattern.
 - Repository responsibilities:
   - upsert the current player action for `(gameId, playerId, tick)`
@@ -102,6 +113,7 @@ Chosen product rules for this plan:
 - Add the new router to `createApi.ts` and export any needed frontend API types.
 
 ### Tick processing
+
 - Extend `processTick` to load all selected actions for `(gameId, gameState.tick)` before resolving players.
 - Per player, resolve in this order:
   1. apply the existing passive `+1 MONEY`
@@ -121,6 +133,7 @@ Chosen product rules for this plan:
 - Keep the implementation dependency-injected and `Result`-based, with no new module-scope state.
 
 ### Frontend
+
 - Extend the `/play/$gameId` page to fetch both:
   - current game state
   - current player action
@@ -135,18 +148,22 @@ Chosen product rules for this plan:
 - If winner persistence is surfaced in existing game summary/status views, show ended state consistently; winner display on the frontend can be limited to the play page or deferred unless already needed by the changed screens.
 
 ## Detailed Steps
+
 ### Step 1: Schema and types
+
 - Add `winnerPlayerId` to `gamesTable` with a nullable FK to `playersTable`.
 - Add `gamePlayerActionsTable` with `gameId`, `playerId`, `tick`, `actionType`, `createdAt`, and `updatedAt`.
 - Use FK constraints back to the game/player membership shape so action rows stay tied to valid game participants.
 - Update generated migration artifacts and any inferred repository row types.
 
 ### Step 2: Action domain model
+
 - Add a backend module for player action constants using the repo’s `as const` pattern.
 - Define the supported action ids and their cost/effect metadata in one place.
 - Add a Zod schema and exported type for `GamePlayerAction`.
 
 ### Step 3: Repository layer
+
 - Create a `GamePlayerActionsRepository`.
 - Implement upsert-by-primary-key for `(gameId, playerId, tick)`.
 - Implement `getByGameIdPlayerIdAndTick`.
@@ -154,6 +171,7 @@ Chosen product rules for this plan:
 - Keep all DB access isolated in this repository.
 
 ### Step 4: Controller layer
+
 - Create a `GamePlayerActionsController`.
 - On `setCurrent`, fetch the player’s current game state to obtain the active tick and current money.
 - Reject writes when the game state does not exist, the player is not in the game, the game has ended, or the action is unaffordable.
@@ -161,6 +179,7 @@ Chosen product rules for this plan:
 - On `getCurrent`, read the current tick first and then fetch the action for that tick only.
 
 ### Step 5: Router integration
+
 - Add `gamePlayerActions.router.ts`.
 - Add private procedures for `getCurrent` and `setCurrent`.
 - Keep the same DI and return-type pattern as the existing routers.
@@ -168,6 +187,7 @@ Chosen product rules for this plan:
 - Export any frontend-consumed output types if needed.
 
 ### Step 6: Tick-processing integration
+
 - Inject `GamePlayerActionsRepository` into the tick-processing entrypoint and `processTick`.
 - For each game tick being processed, fetch actions by `(gameId, gameState.tick)` once before looping players.
 - Match actions to players during resolution.
@@ -177,6 +197,7 @@ Chosen product rules for this plan:
 - Do not delete or mutate historical action rows once the tick is processed.
 
 ### Step 7: Frontend integration
+
 - Add frontend usage of the new router methods in `play.$gameId.tsx`.
 - Query the current action alongside the existing game-state query.
 - Render a minimal action menu with clear selected/unselected states.
@@ -184,12 +205,14 @@ Chosen product rules for this plan:
 - Keep the UI resilient when no action exists for the current tick.
 
 ### Step 8: Verification pass
+
 - Validate append-only DB behavior for multiple ticks.
 - Validate that changing the action before processing overwrites only the current tick row.
 - Validate that advancing the tick results in no selected action for the new tick.
 - Validate that winning ends the game and persists the winner.
 
 ## Public Interfaces / Types
+
 - New backend action type enum-like constant and Zod schema for `GamePlayerAction`.
 - New tRPC router namespace: `gamePlayerActions`.
 - New API payload shape:
@@ -197,6 +220,7 @@ Chosen product rules for this plan:
 - Extend game types as needed to include `winnerPlayerId: number | null` where ended-game winner display is required.
 
 ## Test Plan
+
 - DB/repository checks:
   - can upsert an action for a player in a game and tick
   - updating the action replaces the previous selection for the same `(gameId, playerId, tick)` instead of creating duplicates
@@ -220,6 +244,7 @@ Chosen product rules for this plan:
   - winning action transitions the game to ended state and prevents further play actions
 
 ## Assumptions
+
 - Action visibility is private: only the current player can read their own selected action.
 - “Hard error on affordability” means affordability is checked at submission time, not deferred to tick resolution.
 - `game_player_actions` is the action-history system for v1, but reads and writes only target the current tick unless tick processing is fetching rows to resolve.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,112 @@
+# Player Actions V1
+
+## Summary
+Add per-player, per-game action selection for active games with two actions: `MAKE_MORE_MONEY` and `WIN_THE_GAME`. Players choose at most one action for the upcoming tick from the play screen, can change it any time before processing starts, and their current selection persists across page refreshes. Tick processing resolves the selected action for the current tick without deleting historical action rows.
+
+Chosen product rules for this plan:
+- Ticks keep the existing passive `+1 money`.
+- Action submission is rejected unless the player can already afford the action at submit time.
+- Current selections are private to the current player only.
+- Winning must persist the winner.
+
+## Implementation Changes
+### Data model
+- Add a new `game_player_actions` table keyed by `(gameId, playerId, tick)` with:
+  - `gameId`
+  - `playerId`
+  - `tick`
+  - `actionType`
+  - `createdAt`
+  - `updatedAt`
+- Treat this table as append-only history. A player’s current action is the row for the game’s current tick, and changing the action before processing updates that same `(gameId, playerId, tick)` row.
+- Add a `winnerPlayerId` nullable FK on `games` so ended games can persist the winner.
+- Keep action costs and rewards in backend constants, using the existing `as const` pattern:
+  - `MAKE_MORE_MONEY`: cost `2 MONEY`, reward `5 MONEY`
+  - `WIN_THE_GAME`: cost `10 MONEY`, ends the game, no resource reward
+- Generate a migration for both schema changes and update Drizzle schema/types accordingly.
+
+### Backend API and business logic
+- Add a dedicated player-actions backend slice following the existing router/controller/repository pattern.
+- Repository responsibilities:
+  - upsert the current player action for `(gameId, playerId, tick)`
+  - fetch the current player action for `(gameId, playerId, tick)`
+  - fetch all actions for `(gameId, tick)` during tick processing
+- Controller responsibilities:
+  - verify the game exists and is started but not ended
+  - verify the player belongs to the game
+  - resolve the game’s current tick from `game_states` and always submit against that tick
+  - verify affordability at submission time using current resources
+  - map DB rows to API types
+- tRPC routes:
+  - `gamePlayerActions.getCurrent({ gameId }) -> { action: GamePlayerAction | null }`
+  - `gamePlayerActions.setCurrent({ gameId, actionType }) -> { action: GamePlayerAction }`
+- Add the new router to `createApi.ts` and export any needed frontend API types.
+
+### Tick processing
+- Extend `processTick` to load all selected actions for `(gameId, gameState.tick)` before resolving players.
+- Per player, resolve in this order:
+  1. apply the existing passive `+1 MONEY`
+  2. if no selected action, continue
+  3. if selected action is `MAKE_MORE_MONEY`, subtract `2 MONEY` then add `5 MONEY`
+  4. if selected action is `WIN_THE_GAME`, subtract `10 MONEY`, mark the game ended, and set `winnerPlayerId`
+- Since submission already enforces affordability, tick processing can treat selected actions as executable invariants; if data is inconsistent, log and fail that tick rather than silently changing behavior.
+- When a winning action succeeds:
+  - update `games.endedAt` and `games.winnerPlayerId`
+  - do not schedule another tick for that game
+  - still mark the current tick as finished
+- For non-winning ticks:
+  - preserve current next-tick scheduling/state update behavior
+  - do not delete or clear any action rows; the next tick naturally reads a different `(gameId, tick)` slice
+- For non-winning ticks:
+  - preserve current next-tick scheduling/state update behavior
+- Keep the implementation dependency-injected and `Result`-based, with no new module-scope state.
+
+### Frontend
+- Extend the `/play/$gameId` page to fetch both:
+  - current game state
+  - current player action
+- Add a basic action menu on the play screen, colocated with current tick/resources, with:
+  - a button or simple selectable card for `Make More Money`
+  - a button or simple selectable card for `Win The Game`
+  - disabled state and inline reason when the current money is below the action cost
+  - visible indication of the currently selected action
+- Mutating the selection should refresh the current action query so a page refresh shows the persisted choice.
+- After a tick processes and actions are reset, the page should show no selected action on the next successful refetch.
+- After a tick processes, the page should show no selected action for the new current tick unless the player chooses another one.
+- If winner persistence is surfaced in existing game summary/status views, show ended state consistently; winner display on the frontend can be limited to the play page or deferred unless already needed by the changed screens.
+
+## Public Interfaces / Types
+- New backend action type enum-like constant and Zod schema for `GamePlayerAction`.
+- New tRPC router namespace: `gamePlayerActions`.
+- New API payload shape:
+  - `GamePlayerAction = { gameId: number; playerId: number; tick: number; actionType: "MAKE_MORE_MONEY" | "WIN_THE_GAME"; updatedAt: Date }`
+- Extend game types as needed to include `winnerPlayerId: number | null` where ended-game winner display is required.
+
+## Test Plan
+- DB/repository checks:
+  - can upsert an action for a player in a game and tick
+  - updating the action replaces the previous selection for the same `(gameId, playerId, tick)` instead of creating duplicates
+  - actions for prior ticks remain stored after processing
+  - fetching actions by `(gameId, tick)` returns only that tick’s rows
+- Controller/router checks:
+  - rejects action submission for non-members
+  - rejects action submission for not-started or ended games
+  - rejects `MAKE_MORE_MONEY` below `2 money`
+  - rejects `WIN_THE_GAME` below `10 money`
+  - returns persisted current action after refresh/read
+- Tick-processing scenarios:
+  - no selected action: player still gets `+1 money`
+  - `MAKE_MORE_MONEY`: player with `2` money ends tick at `6` (`2 + 1 - 2 + 5`)
+  - `WIN_THE_GAME`: player with `10` money ends the game, winner is stored, no next tick is scheduled
+  - after a tick advances, the next tick has no current selection until a new row is submitted for that new tick
+- Manual verification:
+  - select action on `/play/$gameId`, refresh, selection remains
+  - change selection before tick, latest choice is the one persisted
+  - once the tick passes and data refetches, selection is empty for the new current tick while the old row remains in the database
+  - winning action transitions the game to ended state and prevents further play actions
+
+## Assumptions
+- Action visibility is private: only the current player can read their own selected action.
+- “Hard error on affordability” means affordability is checked at submission time, not deferred to tick resolution.
+- `game_player_actions` is the action-history system for v1, but reads and writes only target the current tick unless tick processing is fetching rows to resolve.
+- Tick processing remains sequential per game as it is now; this plan does not add broader locking or transactional refactors beyond what is needed for action resolution and reset.

--- a/backend/drizzle/0002_player_actions_v1.sql
+++ b/backend/drizzle/0002_player_actions_v1.sql
@@ -1,0 +1,15 @@
+ALTER TABLE "games" ADD COLUMN "winnerPlayerId" integer;
+--> statement-breakpoint
+ALTER TABLE "games" ADD CONSTRAINT "games_winnerPlayerId_players_id_fk" FOREIGN KEY ("winnerPlayerId") REFERENCES "public"."players"("id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+CREATE TABLE "game_player_actions" (
+	"gameId" integer NOT NULL,
+	"playerId" integer NOT NULL,
+	"tick" integer NOT NULL,
+	"actionType" varchar(255) NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	"updatedAt" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "game_player_actions_gameId_playerId_tick_pk" PRIMARY KEY("gameId","playerId","tick")
+);
+--> statement-breakpoint
+ALTER TABLE "game_player_actions" ADD CONSTRAINT "game_player_actions_gameId_playerId_game_players_fk" FOREIGN KEY ("gameId","playerId") REFERENCES "public"."game_players"("gameId","playerId") ON DELETE cascade ON UPDATE no action;

--- a/backend/drizzle/meta/0002_snapshot.json
+++ b/backend/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,522 @@
+{
+  "id": "55d22349-837f-4e9c-a23a-1f5dc1a9b9d1",
+  "prevId": "ec502858-a844-43f0-8608-17c5c0dbb094",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.game_player_resources": {
+      "name": "game_player_resources",
+      "schema": "",
+      "columns": {
+        "gameId": {
+          "name": "gameId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playerId": {
+          "name": "playerId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceType": {
+          "name": "resourceType",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_player_resources_gameId_playerId_game_players_fk": {
+          "name": "game_player_resources_gameId_playerId_game_players_fk",
+          "tableFrom": "game_player_resources",
+          "tableTo": "game_players",
+          "columnsFrom": [
+            "gameId",
+            "playerId"
+          ],
+          "columnsTo": [
+            "gameId",
+            "playerId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "game_player_resources_gameId_playerId_resourceType_pk": {
+          "name": "game_player_resources_gameId_playerId_resourceType_pk",
+          "columns": [
+            "gameId",
+            "playerId",
+            "resourceType"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_players": {
+      "name": "game_players",
+      "schema": "",
+      "columns": {
+        "gameId": {
+          "name": "gameId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playerId": {
+          "name": "playerId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joinedAt": {
+          "name": "joinedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_players_gameId_games_id_fk": {
+          "name": "game_players_gameId_games_id_fk",
+          "tableFrom": "game_players",
+          "tableTo": "games",
+          "columnsFrom": [
+            "gameId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_players_playerId_players_id_fk": {
+          "name": "game_players_playerId_players_id_fk",
+          "tableFrom": "game_players",
+          "tableTo": "players",
+          "columnsFrom": [
+            "playerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "game_players_gameId_playerId_pk": {
+          "name": "game_players_gameId_playerId_pk",
+          "columns": [
+            "gameId",
+            "playerId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_states": {
+      "name": "game_states",
+      "schema": "",
+      "columns": {
+        "gameId": {
+          "name": "gameId",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tick": {
+          "name": "tick",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "nextTickAt": {
+          "name": "nextTickAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_states_gameId_games_id_fk": {
+          "name": "game_states_gameId_games_id_fk",
+          "tableFrom": "game_states",
+          "tableTo": "games",
+          "columnsFrom": [
+            "gameId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_ticks": {
+      "name": "game_ticks",
+      "schema": "",
+      "columns": {
+        "gameId": {
+          "name": "gameId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tick": {
+          "name": "tick",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduledFor": {
+          "name": "scheduledFor",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processingStartedAt": {
+          "name": "processingStartedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processingEndedAt": {
+          "name": "processingEndedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "game_ticks_scheduledFor_index": {
+          "name": "game_ticks_scheduledFor_index",
+          "columns": [
+            {
+              "expression": "scheduledFor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_ticks_gameId_games_id_fk": {
+          "name": "game_ticks_gameId_games_id_fk",
+          "tableFrom": "game_ticks",
+          "tableTo": "games",
+          "columnsFrom": [
+            "gameId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "game_ticks_gameId_tick_pk": {
+          "name": "game_ticks_gameId_tick_pk",
+          "columns": [
+            "gameId",
+            "tick"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "games_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdByPlayerId": {
+          "name": "createdByPlayerId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nbSeats": {
+          "name": "nbSeats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tickIntervalSeconds": {
+          "name": "tickIntervalSeconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winnerPlayerId": {
+          "name": "winnerPlayerId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "games_createdByPlayerId_players_id_fk": {
+          "name": "games_createdByPlayerId_players_id_fk",
+          "tableFrom": "games",
+          "tableTo": "players",
+          "columnsFrom": [
+            "createdByPlayerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "games_winnerPlayerId_players_id_fk": {
+          "name": "games_winnerPlayerId_players_id_fk",
+          "tableFrom": "games",
+          "tableTo": "players",
+          "columnsFrom": [
+            "winnerPlayerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.players": {
+      "name": "players",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "players_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clerk_id_idx": {
+          "name": "clerk_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_player_actions": {
+      "name": "game_player_actions",
+      "schema": "",
+      "columns": {
+        "gameId": {
+          "name": "gameId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playerId": {
+          "name": "playerId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tick": {
+          "name": "tick",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actionType": {
+          "name": "actionType",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_player_actions_gameId_playerId_game_players_fk": {
+          "name": "game_player_actions_gameId_playerId_game_players_fk",
+          "tableFrom": "game_player_actions",
+          "tableTo": "game_players",
+          "columnsFrom": [
+            "gameId",
+            "playerId"
+          ],
+          "columnsTo": [
+            "gameId",
+            "playerId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "game_player_actions_gameId_playerId_tick_pk": {
+          "name": "game_player_actions_gameId_playerId_tick_pk",
+          "columns": [
+            "gameId",
+            "playerId",
+            "tick"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/0002_snapshot.json
+++ b/backend/drizzle/meta/0002_snapshot.json
@@ -40,14 +40,8 @@
           "name": "game_player_resources_gameId_playerId_game_players_fk",
           "tableFrom": "game_player_resources",
           "tableTo": "game_players",
-          "columnsFrom": [
-            "gameId",
-            "playerId"
-          ],
-          "columnsTo": [
-            "gameId",
-            "playerId"
-          ],
+          "columnsFrom": ["gameId", "playerId"],
+          "columnsTo": ["gameId", "playerId"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -55,11 +49,7 @@
       "compositePrimaryKeys": {
         "game_player_resources_gameId_playerId_resourceType_pk": {
           "name": "game_player_resources_gameId_playerId_resourceType_pk",
-          "columns": [
-            "gameId",
-            "playerId",
-            "resourceType"
-          ]
+          "columns": ["gameId", "playerId", "resourceType"]
         }
       },
       "uniqueConstraints": {},
@@ -97,12 +87,8 @@
           "name": "game_players_gameId_games_id_fk",
           "tableFrom": "game_players",
           "tableTo": "games",
-          "columnsFrom": [
-            "gameId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["gameId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -110,12 +96,8 @@
           "name": "game_players_playerId_players_id_fk",
           "tableFrom": "game_players",
           "tableTo": "players",
-          "columnsFrom": [
-            "playerId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["playerId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -123,10 +105,7 @@
       "compositePrimaryKeys": {
         "game_players_gameId_playerId_pk": {
           "name": "game_players_gameId_playerId_pk",
-          "columns": [
-            "gameId",
-            "playerId"
-          ]
+          "columns": ["gameId", "playerId"]
         }
       },
       "uniqueConstraints": {},
@@ -164,12 +143,8 @@
           "name": "game_states_gameId_games_id_fk",
           "tableFrom": "game_states",
           "tableTo": "games",
-          "columnsFrom": [
-            "gameId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["gameId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -237,12 +212,8 @@
           "name": "game_ticks_gameId_games_id_fk",
           "tableFrom": "game_ticks",
           "tableTo": "games",
-          "columnsFrom": [
-            "gameId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["gameId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -250,10 +221,7 @@
       "compositePrimaryKeys": {
         "game_ticks_gameId_tick_pk": {
           "name": "game_ticks_gameId_tick_pk",
-          "columns": [
-            "gameId",
-            "tick"
-          ]
+          "columns": ["gameId", "tick"]
         }
       },
       "uniqueConstraints": {},
@@ -338,12 +306,8 @@
           "name": "games_createdByPlayerId_players_id_fk",
           "tableFrom": "games",
           "tableTo": "players",
-          "columnsFrom": [
-            "createdByPlayerId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["createdByPlayerId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -351,12 +315,8 @@
           "name": "games_winnerPlayerId_players_id_fk",
           "tableFrom": "games",
           "tableTo": "players",
-          "columnsFrom": [
-            "winnerPlayerId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["winnerPlayerId"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -480,14 +440,8 @@
           "name": "game_player_actions_gameId_playerId_game_players_fk",
           "tableFrom": "game_player_actions",
           "tableTo": "game_players",
-          "columnsFrom": [
-            "gameId",
-            "playerId"
-          ],
-          "columnsTo": [
-            "gameId",
-            "playerId"
-          ],
+          "columnsFrom": ["gameId", "playerId"],
+          "columnsTo": ["gameId", "playerId"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -495,11 +449,7 @@
       "compositePrimaryKeys": {
         "game_player_actions_gameId_playerId_tick_pk": {
           "name": "game_player_actions_gameId_playerId_tick_pk",
-          "columns": [
-            "gameId",
-            "playerId",
-            "tick"
-          ]
+          "columns": ["gameId", "playerId", "tick"]
         }
       },
       "uniqueConstraints": {},

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1776306614224,
       "tag": "0001_overrated_abomination",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1776390000000,
+      "tag": "0002_player_actions_v1",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/api/createApi.ts
+++ b/backend/src/api/createApi.ts
@@ -14,6 +14,9 @@ import type { GameStatesRepository } from "#lib/db/gameStates.repository.ts"
 import { PlayersController } from "#api/players/players.controller.ts"
 import type { PlayersRepository } from "#lib/db/players.repository.ts"
 import type { GamePlayerResourcesRepository } from "#lib/db/gamePlayerResources.repository.ts"
+import type { GamePlayerActionsRepository } from "#lib/db/gamePlayerActions.repository.ts"
+import { GamePlayerActionsController } from "#api/gamePlayerActions/gamePlayerActions.controller.ts"
+import { createGamePlayerActionsRouter } from "#api/gamePlayerActions/gamePlayerActions.router.ts"
 
 /**
  * Import side effect free express app creator.
@@ -30,11 +33,13 @@ export async function createApi({
   gamesRepository: GamesRepository
   gameStatesRepository: GameStatesRepository
   gamePlayerResourcesRepository: GamePlayerResourcesRepository
+  gamePlayerActionsRepository: GamePlayerActionsRepository
 }): Promise<Express> {
   const controllers = {
     gamesController: new GamesController(services),
     gameStatesController: new GameStatesController(services),
     playersController: new PlayersController(services),
+    gamePlayerActionsController: new GamePlayerActionsController(services),
   }
 
   const app = express()
@@ -55,13 +60,19 @@ export async function createApi({
 
 export type TrpcRouter = ReturnType<typeof createTrpcRouter>
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- Let trpc inference do the work
-function createTrpcRouter(services: { gamesController: GamesController; gameStatesController: GameStatesController; logger: Logger }) {
+function createTrpcRouter(services: {
+  gamesController: GamesController
+  gameStatesController: GameStatesController
+  gamePlayerActionsController: GamePlayerActionsController
+  logger: Logger
+}) {
   const trpc = createTrpc()
   const routerServices = { trpc, ...services }
 
   return trpc.router({
     games: createGamesRouter(routerServices),
     gameStates: createGameStatesRouter(routerServices),
+    gamePlayerActions: createGamePlayerActionsRouter(routerServices),
   })
 }
 

--- a/backend/src/api/entry.api.ts
+++ b/backend/src/api/entry.api.ts
@@ -12,6 +12,7 @@ import { configureLogger } from "#lib/configureLogger.ts"
 import { connectToDb } from "#lib/db/connectToDb.ts"
 import { GameStatesRepository } from "#lib/db/gameStates.repository.ts"
 import { GamePlayerResourcesRepository } from "#lib/db/gamePlayerResources.repository.ts"
+import { GamePlayerActionsRepository } from "#lib/db/gamePlayerActions.repository.ts"
 
 main().catch((error) => {
   Logger.get().error("Unhandled application error", { error })
@@ -40,6 +41,7 @@ async function main(): Promise<void> {
     gamesRepository: new GamesRepository({ db, logger }),
     gameStatesRepository: new GameStatesRepository({ db, logger }),
     gamePlayerResourcesRepository: new GamePlayerResourcesRepository({ db, logger }),
+    gamePlayerActionsRepository: new GamePlayerActionsRepository({ db, logger }),
   }
 
   const authService = new AuthService({ logger })

--- a/backend/src/api/gamePlayerActions/gamePlayerActions.controller.ts
+++ b/backend/src/api/gamePlayerActions/gamePlayerActions.controller.ts
@@ -1,0 +1,146 @@
+import { type Logger, Result } from "@guillaume-docquier/tools-ts"
+import type { GamePlayerActionsRepository, GamePlayerActionRow } from "#lib/db/gamePlayerActions.repository.ts"
+import type { GameStatesRepository } from "#lib/db/gameStates.repository.ts"
+import type { GamesRepository } from "#lib/db/games.repository.ts"
+import { GamePlayerAction, GAME_PLAYER_ACTION_RULES, type GamePlayerActionType } from "#lib/gamePlayerActions.ts"
+
+export class GamePlayerActionsController {
+  private readonly gamePlayerActionsRepository: GamePlayerActionsRepository
+  private readonly gameStatesRepository: GameStatesRepository
+  private readonly gamesRepository: GamesRepository
+  private readonly logger: Logger
+
+  public constructor({
+    gamePlayerActionsRepository,
+    gameStatesRepository,
+    gamesRepository,
+    logger,
+  }: {
+    gamePlayerActionsRepository: GamePlayerActionsRepository
+    gameStatesRepository: GameStatesRepository
+    gamesRepository: GamesRepository
+    logger: Logger
+  }) {
+    this.gamePlayerActionsRepository = gamePlayerActionsRepository
+    this.gameStatesRepository = gameStatesRepository
+    this.gamesRepository = gamesRepository
+    this.logger = logger.child({ scope: "game-player-actions-controller" })
+  }
+
+  public async getCurrent({
+    gameId,
+    playerId,
+  }: {
+    gameId: number
+    playerId: number
+  }): Promise<Result<GamePlayerAction | undefined, string>> {
+    const activeGameResult = await this.getActiveGameForPlayer({ gameId, playerId })
+    if (Result.isFailure(activeGameResult)) {
+      return activeGameResult
+    }
+
+    const getCurrentResult = await this.gamePlayerActionsRepository.getByGameIdPlayerIdAndTick({
+      gameId,
+      playerId,
+      tick: activeGameResult.value.tick,
+    })
+    if (Result.isFailure(getCurrentResult)) {
+      this.logger.error("Could not get current game player action", { gameId, playerId, error: getCurrentResult.error })
+      return getCurrentResult
+    }
+
+    const currentAction = getCurrentResult.value
+    return Result.Success(currentAction === undefined ? undefined : toGamePlayerAction(currentAction))
+  }
+
+  public async setCurrent({
+    gameId,
+    playerId,
+    actionType,
+  }: {
+    gameId: number
+    playerId: number
+    actionType: GamePlayerActionType
+  }): Promise<Result<GamePlayerAction, string>> {
+    const activeGameResult = await this.getActiveGameForPlayer({ gameId, playerId })
+    if (Result.isFailure(activeGameResult)) {
+      return activeGameResult
+    }
+
+    const { tick, money } = activeGameResult.value
+    const actionRule = GAME_PLAYER_ACTION_RULES[actionType]
+    if (money < actionRule.costMoney) {
+      return Result.Failure(`You need ${actionRule.costMoney} money to select this action.`)
+    }
+
+    const upsertResult = await this.gamePlayerActionsRepository.upsert({
+      gameId,
+      playerId,
+      tick,
+      actionType,
+    })
+    if (Result.isFailure(upsertResult)) {
+      this.logger.error("Could not set current game player action", { gameId, playerId, actionType, error: upsertResult.error })
+      return upsertResult
+    }
+
+    return Result.Success(toGamePlayerAction(upsertResult.value))
+  }
+
+  private async getActiveGameForPlayer({
+    gameId,
+    playerId,
+  }: {
+    gameId: number
+    playerId: number
+  }): Promise<Result<{ tick: number; money: number }, string>> {
+    const gameSummaryResult = await this.gamesRepository.getSummaryById({ gameId })
+    if (Result.isFailure(gameSummaryResult)) {
+      this.logger.error("Could not get game summary while resolving action context", { gameId, playerId, error: gameSummaryResult.error })
+      return Result.Failure(gameSummaryResult.error)
+    }
+
+    const gameSummary = gameSummaryResult.value
+    if (gameSummary === undefined) {
+      return Result.Failure("Game does not exist.")
+    }
+
+    if (gameSummary.startedAt === null) {
+      return Result.Failure("Game has not started.")
+    }
+
+    if (gameSummary.endedAt !== null) {
+      return Result.Failure("Game has ended.")
+    }
+
+    if (!gameSummary.players.some((player) => player.id === playerId)) {
+      return Result.Failure("Player is not in this game.")
+    }
+
+    const gameStateResult = await this.gameStatesRepository.getByGameIdAndPlayerId({ gameId, playerId })
+    if (Result.isFailure(gameStateResult)) {
+      this.logger.error("Could not get game state while resolving action context", { gameId, playerId, error: gameStateResult.error })
+      return Result.Failure(gameStateResult.error)
+    }
+
+    const gameState = gameStateResult.value
+    if (gameState === undefined) {
+      return Result.Failure("Game state does not exist.")
+    }
+
+    return Result.Success({
+      tick: gameState.tick,
+      money: gameState.resources.money,
+    })
+  }
+}
+
+function toGamePlayerAction(gamePlayerActionRow: GamePlayerActionRow): GamePlayerAction {
+  return {
+    gameId: gamePlayerActionRow.gameId,
+    playerId: gamePlayerActionRow.playerId,
+    tick: gamePlayerActionRow.tick,
+    actionType: gamePlayerActionRow.actionType,
+    updatedAt: gamePlayerActionRow.updatedAt,
+  }
+}

--- a/backend/src/api/gamePlayerActions/gamePlayerActions.controller.ts
+++ b/backend/src/api/gamePlayerActions/gamePlayerActions.controller.ts
@@ -2,7 +2,7 @@ import { type Logger, Result } from "@guillaume-docquier/tools-ts"
 import type { GamePlayerActionsRepository, GamePlayerActionRow } from "#lib/db/gamePlayerActions.repository.ts"
 import type { GameStatesRepository } from "#lib/db/gameStates.repository.ts"
 import type { GamesRepository } from "#lib/db/games.repository.ts"
-import { GamePlayerAction, GAME_PLAYER_ACTION_RULES, type GamePlayerActionType } from "#lib/gamePlayerActions.ts"
+import { type GamePlayerAction, GAME_PLAYER_ACTION_RULES, type GamePlayerActionType } from "#lib/gamePlayerActions.ts"
 
 export class GamePlayerActionsController {
   private readonly gamePlayerActionsRepository: GamePlayerActionsRepository

--- a/backend/src/api/gamePlayerActions/gamePlayerActions.controller.ts
+++ b/backend/src/api/gamePlayerActions/gamePlayerActions.controller.ts
@@ -33,7 +33,7 @@ export class GamePlayerActionsController {
   }: {
     gameId: number
     playerId: number
-  }): Promise<Result<GamePlayerAction | undefined, string>> {
+  }): Promise<Result<GamePlayerAction | null, string>> {
     const activeGameResult = await this.getActiveGameForPlayer({ gameId, playerId })
     if (Result.isFailure(activeGameResult)) {
       return activeGameResult
@@ -49,8 +49,8 @@ export class GamePlayerActionsController {
     }
 
     const currentAction = getCurrentActionResult.value
-    if (currentAction === undefined) {
-      return Result.Success(undefined)
+    if (currentAction === null) {
+      return Result.Success(null)
     }
 
     return Result.Success(toGamePlayerAction(currentAction))
@@ -64,7 +64,7 @@ export class GamePlayerActionsController {
     gameId: number
     playerId: number
     actionType: GamePlayerActionType | null
-  }): Promise<Result<GamePlayerAction | undefined, string>> {
+  }): Promise<Result<GamePlayerAction | null, string>> {
     const activeGameResult = await this.getActiveGameForPlayer({ gameId, playerId })
     if (Result.isFailure(activeGameResult)) {
       return activeGameResult
@@ -81,7 +81,7 @@ export class GamePlayerActionsController {
         return deleteResult
       }
 
-      return Result.Success(undefined)
+      return Result.Success(null)
     }
 
     const actionRule = GAME_PLAYER_ACTION_RULES[actionType]

--- a/backend/src/api/gamePlayerActions/gamePlayerActions.controller.ts
+++ b/backend/src/api/gamePlayerActions/gamePlayerActions.controller.ts
@@ -2,7 +2,7 @@ import { type Logger, Result } from "@guillaume-docquier/tools-ts"
 import type { GamePlayerActionsRepository, GamePlayerActionRow } from "#lib/db/gamePlayerActions.repository.ts"
 import type { GameStatesRepository } from "#lib/db/gameStates.repository.ts"
 import type { GamesRepository } from "#lib/db/games.repository.ts"
-import { type GamePlayerAction, GAME_PLAYER_ACTION_RULES, type GamePlayerActionType } from "#lib/gamePlayerActions.ts"
+import { GAME_PLAYER_ACTION_RULES, type GamePlayerActionType, type GamePlayerAction } from "#lib/gamePlayerActions.ts"
 
 export class GamePlayerActionsController {
   private readonly gamePlayerActionsRepository: GamePlayerActionsRepository
@@ -165,7 +165,7 @@ function toGamePlayerAction(gamePlayerActionRow: GamePlayerActionRow): GamePlaye
     gameId: gamePlayerActionRow.gameId,
     playerId: gamePlayerActionRow.playerId,
     tick: gamePlayerActionRow.tick,
-    actionType: gamePlayerActionRow.actionType,
+    actionType: gamePlayerActionRow.actionType as GamePlayerActionType, // probably would want to validate this, or store in db as enum
     updatedAt: gamePlayerActionRow.updatedAt,
   }
 }

--- a/backend/src/api/gamePlayerActions/gamePlayerActions.controller.ts
+++ b/backend/src/api/gamePlayerActions/gamePlayerActions.controller.ts
@@ -58,11 +58,13 @@ export class GamePlayerActionsController {
 
   public async setCurrentAction({
     gameId,
+    tick,
     playerId,
     actionType,
   }: {
     gameId: number
     playerId: number
+    tick: number
     actionType: GamePlayerActionType | null
   }): Promise<Result<GamePlayerAction | null, string>> {
     const activeGameResult = await this.getActiveGameForPlayer({ gameId, playerId })
@@ -70,7 +72,10 @@ export class GamePlayerActionsController {
       return activeGameResult
     }
 
-    const { tick, money } = activeGameResult.value
+    if (activeGameResult.value.tick !== tick) {
+      return Result.Failure(`Cannot submit action for tick ${tick}, the game is currently at tick ${activeGameResult.value.tick}.`)
+    }
+
     if (actionType === null) {
       const deleteResult = await this.gamePlayerActionsRepository.deleteByGameIdPlayerIdAndTick({
         gameId,
@@ -85,12 +90,12 @@ export class GamePlayerActionsController {
     }
 
     const actionRule = GAME_PLAYER_ACTION_RULES[actionType]
-    if (money < actionRule.costMoney) {
+    if (activeGameResult.value.money < actionRule.costMoney) {
       this.logger.error("Player cannot afford selected game player action", {
         gameId,
         playerId,
         actionType,
-        money,
+        money: activeGameResult.value.money,
         costMoney: actionRule.costMoney,
       })
       return Result.Failure(`You need ${actionRule.costMoney} money to select this action.`)

--- a/backend/src/api/gamePlayerActions/gamePlayerActions.controller.ts
+++ b/backend/src/api/gamePlayerActions/gamePlayerActions.controller.ts
@@ -60,14 +60,28 @@ export class GamePlayerActionsController {
   }: {
     gameId: number
     playerId: number
-    actionType: GamePlayerActionType
-  }): Promise<Result<GamePlayerAction, string>> {
+    actionType: GamePlayerActionType | null
+  }): Promise<Result<GamePlayerAction | undefined, string>> {
     const activeGameResult = await this.getActiveGameForPlayer({ gameId, playerId })
     if (Result.isFailure(activeGameResult)) {
       return activeGameResult
     }
 
     const { tick, money } = activeGameResult.value
+    if (actionType === null) {
+      const deleteResult = await this.gamePlayerActionsRepository.deleteByGameIdPlayerIdAndTick({
+        gameId,
+        playerId,
+        tick,
+      })
+      if (Result.isFailure(deleteResult)) {
+        this.logger.error("Could not clear current game player action", { gameId, playerId, error: deleteResult.error })
+        return deleteResult
+      }
+
+      return Result.Success(undefined)
+    }
+
     const actionRule = GAME_PLAYER_ACTION_RULES[actionType]
     if (money < actionRule.costMoney) {
       return Result.Failure(`You need ${actionRule.costMoney} money to select this action.`)

--- a/backend/src/api/gamePlayerActions/gamePlayerActions.controller.ts
+++ b/backend/src/api/gamePlayerActions/gamePlayerActions.controller.ts
@@ -27,7 +27,7 @@ export class GamePlayerActionsController {
     this.logger = logger.child({ scope: "game-player-actions-controller" })
   }
 
-  public async getCurrent({
+  public async getCurrentAction({
     gameId,
     playerId,
   }: {
@@ -39,21 +39,24 @@ export class GamePlayerActionsController {
       return activeGameResult
     }
 
-    const getCurrentResult = await this.gamePlayerActionsRepository.getByGameIdPlayerIdAndTick({
+    const getCurrentActionResult = await this.gamePlayerActionsRepository.getByGameIdPlayerIdAndTick({
       gameId,
       playerId,
       tick: activeGameResult.value.tick,
     })
-    if (Result.isFailure(getCurrentResult)) {
-      this.logger.error("Could not get current game player action", { gameId, playerId, error: getCurrentResult.error })
-      return getCurrentResult
+    if (Result.isFailure(getCurrentActionResult)) {
+      return getCurrentActionResult
     }
 
-    const currentAction = getCurrentResult.value
-    return Result.Success(currentAction === undefined ? undefined : toGamePlayerAction(currentAction))
+    const currentAction = getCurrentActionResult.value
+    if (currentAction === undefined) {
+      return Result.Success(undefined)
+    }
+
+    return Result.Success(toGamePlayerAction(currentAction))
   }
 
-  public async setCurrent({
+  public async setCurrentAction({
     gameId,
     playerId,
     actionType,
@@ -75,7 +78,6 @@ export class GamePlayerActionsController {
         tick,
       })
       if (Result.isFailure(deleteResult)) {
-        this.logger.error("Could not clear current game player action", { gameId, playerId, error: deleteResult.error })
         return deleteResult
       }
 
@@ -84,6 +86,13 @@ export class GamePlayerActionsController {
 
     const actionRule = GAME_PLAYER_ACTION_RULES[actionType]
     if (money < actionRule.costMoney) {
+      this.logger.error("Player cannot afford selected game player action", {
+        gameId,
+        playerId,
+        actionType,
+        money,
+        costMoney: actionRule.costMoney,
+      })
       return Result.Failure(`You need ${actionRule.costMoney} money to select this action.`)
     }
 
@@ -94,7 +103,6 @@ export class GamePlayerActionsController {
       actionType,
     })
     if (Result.isFailure(upsertResult)) {
-      this.logger.error("Could not set current game player action", { gameId, playerId, actionType, error: upsertResult.error })
       return upsertResult
     }
 
@@ -110,35 +118,38 @@ export class GamePlayerActionsController {
   }): Promise<Result<{ tick: number; money: number }, string>> {
     const gameSummaryResult = await this.gamesRepository.getSummaryById({ gameId })
     if (Result.isFailure(gameSummaryResult)) {
-      this.logger.error("Could not get game summary while resolving action context", { gameId, playerId, error: gameSummaryResult.error })
-      return Result.Failure(gameSummaryResult.error)
+      return gameSummaryResult
     }
 
     const gameSummary = gameSummaryResult.value
     if (gameSummary === undefined) {
+      this.logger.error("Cannot resolve action context because game does not exist", { gameId, playerId })
       return Result.Failure("Game does not exist.")
     }
 
     if (gameSummary.startedAt === null) {
+      this.logger.error("Cannot resolve action context because game has not started", { gameId, playerId })
       return Result.Failure("Game has not started.")
     }
 
     if (gameSummary.endedAt !== null) {
+      this.logger.error("Cannot resolve action context because game has ended", { gameId, playerId, endedAt: gameSummary.endedAt })
       return Result.Failure("Game has ended.")
     }
 
     if (!gameSummary.players.some((player) => player.id === playerId)) {
+      this.logger.error("Cannot resolve action context because player is not in game", { gameId, playerId })
       return Result.Failure("Player is not in this game.")
     }
 
     const gameStateResult = await this.gameStatesRepository.getByGameIdAndPlayerId({ gameId, playerId })
     if (Result.isFailure(gameStateResult)) {
-      this.logger.error("Could not get game state while resolving action context", { gameId, playerId, error: gameStateResult.error })
-      return Result.Failure(gameStateResult.error)
+      return gameStateResult
     }
 
     const gameState = gameStateResult.value
     if (gameState === undefined) {
+      this.logger.error("Cannot resolve action context because game state does not exist", { gameId, playerId })
       return Result.Failure("Game state does not exist.")
     }
 

--- a/backend/src/api/gamePlayerActions/gamePlayerActions.router.ts
+++ b/backend/src/api/gamePlayerActions/gamePlayerActions.router.ts
@@ -1,0 +1,52 @@
+import { Result } from "@guillaume-docquier/tools-ts"
+import z from "zod"
+import { TRPCError } from "@trpc/server"
+import type { Trpc } from "#api/trpc.ts"
+import type { GamePlayerActionsController } from "#api/gamePlayerActions/gamePlayerActions.controller.ts"
+import { GamePlayerAction, GamePlayerActionTypeSchema } from "#lib/gamePlayerActions.ts"
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- Let trpc inference do the work
+export function createGamePlayerActionsRouter({
+  t,
+  privateProcedure,
+  gamePlayerActionsController,
+}: Trpc & {
+  gamePlayerActionsController: GamePlayerActionsController
+}) {
+  return t.router({
+    getCurrent: privateProcedure
+      .input(z.object({ gameId: z.coerce.number() }))
+      .output(z.object({ action: GamePlayerAction.nullable() }))
+      .query(async ({ input: { gameId }, ctx: { player } }) => {
+        const getCurrentResult = await gamePlayerActionsController.getCurrent({ gameId, playerId: player.id })
+        if (Result.isFailure(getCurrentResult)) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: getCurrentResult.error,
+          })
+        }
+
+        return { action: getCurrentResult.value ?? null }
+      }),
+
+    setCurrent: privateProcedure
+      .input(
+        z.object({
+          gameId: z.coerce.number(),
+          actionType: GamePlayerActionTypeSchema,
+        }),
+      )
+      .output(z.object({ action: GamePlayerAction }))
+      .mutation(async ({ input: { gameId, actionType }, ctx: { player } }) => {
+        const setCurrentResult = await gamePlayerActionsController.setCurrent({ gameId, playerId: player.id, actionType })
+        if (Result.isFailure(setCurrentResult)) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: setCurrentResult.error,
+          })
+        }
+
+        return { action: setCurrentResult.value }
+      }),
+  })
+}

--- a/backend/src/api/gamePlayerActions/gamePlayerActions.router.ts
+++ b/backend/src/api/gamePlayerActions/gamePlayerActions.router.ts
@@ -14,22 +14,22 @@ export function createGamePlayerActionsRouter({
   gamePlayerActionsController: GamePlayerActionsController
 }) {
   return t.router({
-    getCurrent: privateProcedure
+    getCurrentAction: privateProcedure
       .input(z.object({ gameId: z.coerce.number() }))
-      .output(z.object({ action: GamePlayerAction.nullable() }))
+      .output(z.object({ action: GamePlayerAction.or(z.undefined()) }))
       .query(async ({ input: { gameId }, ctx: { player } }) => {
-        const getCurrentResult = await gamePlayerActionsController.getCurrent({ gameId, playerId: player.id })
-        if (Result.isFailure(getCurrentResult)) {
+        const getCurrentActionResult = await gamePlayerActionsController.getCurrentAction({ gameId, playerId: player.id })
+        if (Result.isFailure(getCurrentActionResult)) {
           throw new TRPCError({
             code: "BAD_REQUEST",
-            message: getCurrentResult.error,
+            message: getCurrentActionResult.error,
           })
         }
 
-        return { action: getCurrentResult.value ?? null }
+        return { action: getCurrentActionResult.value }
       }),
 
-    setCurrent: privateProcedure
+    setCurrentAction: privateProcedure
       .input(
         z.object({
           gameId: z.coerce.number(),
@@ -38,7 +38,7 @@ export function createGamePlayerActionsRouter({
       )
       .output(z.object({ action: GamePlayerAction.nullable() }))
       .mutation(async ({ input: { gameId, actionType }, ctx: { player } }) => {
-        const setCurrentResult = await gamePlayerActionsController.setCurrent({ gameId, playerId: player.id, actionType })
+        const setCurrentResult = await gamePlayerActionsController.setCurrentAction({ gameId, playerId: player.id, actionType })
         if (Result.isFailure(setCurrentResult)) {
           throw new TRPCError({
             code: "BAD_REQUEST",

--- a/backend/src/api/gamePlayerActions/gamePlayerActions.router.ts
+++ b/backend/src/api/gamePlayerActions/gamePlayerActions.router.ts
@@ -7,14 +7,14 @@ import { GamePlayerAction, GamePlayerActionTypeSchema } from "#lib/gamePlayerAct
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- Let trpc inference do the work
 export function createGamePlayerActionsRouter({
-  t,
-  privateProcedure,
+  trpc,
   gamePlayerActionsController,
-}: Trpc & {
+}: {
+  trpc: Trpc
   gamePlayerActionsController: GamePlayerActionsController
 }) {
-  return t.router({
-    getCurrentAction: privateProcedure
+  return trpc.router({
+    getCurrentAction: trpc.privateProcedure
       .input(z.object({ gameId: z.coerce.number() }))
       .output(z.object({ action: GamePlayerAction.or(z.undefined()) }))
       .query(async ({ input: { gameId }, ctx: { player } }) => {
@@ -29,7 +29,7 @@ export function createGamePlayerActionsRouter({
         return { action: getCurrentActionResult.value }
       }),
 
-    setCurrentAction: privateProcedure
+    setCurrentAction: trpc.privateProcedure
       .input(
         z.object({
           gameId: z.coerce.number(),

--- a/backend/src/api/gamePlayerActions/gamePlayerActions.router.ts
+++ b/backend/src/api/gamePlayerActions/gamePlayerActions.router.ts
@@ -3,7 +3,7 @@ import z from "zod"
 import { TRPCError } from "@trpc/server"
 import type { Trpc } from "#api/trpc.ts"
 import type { GamePlayerActionsController } from "#api/gamePlayerActions/gamePlayerActions.controller.ts"
-import { GamePlayerAction, GamePlayerActionTypeSchema } from "#lib/gamePlayerActions.ts"
+import { GamePlayerActionSchema, GamePlayerActionTypeSchema } from "#lib/gamePlayerActions.ts"
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- Let trpc inference do the work
 export function createGamePlayerActionsRouter({
@@ -20,7 +20,7 @@ export function createGamePlayerActionsRouter({
      */
     getCurrentAction: trpc.privateProcedure
       .input(z.object({ gameId: z.coerce.number() }))
-      .output(z.object({ action: GamePlayerAction.nullable() }))
+      .output(z.object({ action: GamePlayerActionSchema.nullable() }))
       .query(async ({ input: { gameId }, ctx: { player } }) => {
         const getCurrentActionResult = await gamePlayerActionsController.getCurrentAction({ gameId, playerId: player.id })
         if (Result.isFailure(getCurrentActionResult)) {
@@ -44,7 +44,7 @@ export function createGamePlayerActionsRouter({
           actionType: GamePlayerActionTypeSchema.nullable(),
         }),
       )
-      .output(z.object({ action: GamePlayerAction.nullable() }))
+      .output(z.object({ action: GamePlayerActionSchema.nullable() }))
       .mutation(async ({ input: { gameId, actionType }, ctx: { player } }) => {
         const setCurrentActionResult = await gamePlayerActionsController.setCurrentAction({ gameId, playerId: player.id, actionType })
         if (Result.isFailure(setCurrentActionResult)) {

--- a/backend/src/api/gamePlayerActions/gamePlayerActions.router.ts
+++ b/backend/src/api/gamePlayerActions/gamePlayerActions.router.ts
@@ -14,9 +14,13 @@ export function createGamePlayerActionsRouter({
   gamePlayerActionsController: GamePlayerActionsController
 }) {
   return trpc.router({
+    /**
+     * Gets the current action of a player for a given game.
+     * Long term you won't have just a single action, and it'll probably be bundled into a single game state query.
+     */
     getCurrentAction: trpc.privateProcedure
       .input(z.object({ gameId: z.coerce.number() }))
-      .output(z.object({ action: GamePlayerAction.or(z.undefined()) }))
+      .output(z.object({ action: GamePlayerAction.nullable() }))
       .query(async ({ input: { gameId }, ctx: { player } }) => {
         const getCurrentActionResult = await gamePlayerActionsController.getCurrentAction({ gameId, playerId: player.id })
         if (Result.isFailure(getCurrentActionResult)) {
@@ -29,6 +33,10 @@ export function createGamePlayerActionsRouter({
         return { action: getCurrentActionResult.value }
       }),
 
+    /**
+     * Sets the current action of a player for a given game.
+     * Long term you won't have just a single action.
+     */
     setCurrentAction: trpc.privateProcedure
       .input(
         z.object({
@@ -38,15 +46,15 @@ export function createGamePlayerActionsRouter({
       )
       .output(z.object({ action: GamePlayerAction.nullable() }))
       .mutation(async ({ input: { gameId, actionType }, ctx: { player } }) => {
-        const setCurrentResult = await gamePlayerActionsController.setCurrentAction({ gameId, playerId: player.id, actionType })
-        if (Result.isFailure(setCurrentResult)) {
+        const setCurrentActionResult = await gamePlayerActionsController.setCurrentAction({ gameId, playerId: player.id, actionType })
+        if (Result.isFailure(setCurrentActionResult)) {
           throw new TRPCError({
             code: "BAD_REQUEST",
-            message: setCurrentResult.error,
+            message: setCurrentActionResult.error,
           })
         }
 
-        return { action: setCurrentResult.value ?? null }
+        return { action: setCurrentActionResult.value }
       }),
   })
 }

--- a/backend/src/api/gamePlayerActions/gamePlayerActions.router.ts
+++ b/backend/src/api/gamePlayerActions/gamePlayerActions.router.ts
@@ -41,12 +41,13 @@ export function createGamePlayerActionsRouter({
       .input(
         z.object({
           gameId: z.coerce.number(),
+          tick: z.coerce.number(),
           actionType: GamePlayerActionTypeSchema.nullable(),
         }),
       )
       .output(z.object({ action: GamePlayerActionSchema.nullable() }))
-      .mutation(async ({ input: { gameId, actionType }, ctx: { player } }) => {
-        const setCurrentActionResult = await gamePlayerActionsController.setCurrentAction({ gameId, playerId: player.id, actionType })
+      .mutation(async ({ input: { gameId, tick, actionType }, ctx: { player } }) => {
+        const setCurrentActionResult = await gamePlayerActionsController.setCurrentAction({ gameId, playerId: player.id, tick, actionType })
         if (Result.isFailure(setCurrentActionResult)) {
           throw new TRPCError({
             code: "BAD_REQUEST",

--- a/backend/src/api/gamePlayerActions/gamePlayerActions.router.ts
+++ b/backend/src/api/gamePlayerActions/gamePlayerActions.router.ts
@@ -33,10 +33,10 @@ export function createGamePlayerActionsRouter({
       .input(
         z.object({
           gameId: z.coerce.number(),
-          actionType: GamePlayerActionTypeSchema,
+          actionType: GamePlayerActionTypeSchema.nullable(),
         }),
       )
-      .output(z.object({ action: GamePlayerAction }))
+      .output(z.object({ action: GamePlayerAction.nullable() }))
       .mutation(async ({ input: { gameId, actionType }, ctx: { player } }) => {
         const setCurrentResult = await gamePlayerActionsController.setCurrent({ gameId, playerId: player.id, actionType })
         if (Result.isFailure(setCurrentResult)) {
@@ -46,7 +46,7 @@ export function createGamePlayerActionsRouter({
           })
         }
 
-        return { action: setCurrentResult.value }
+        return { action: setCurrentResult.value ?? null }
       }),
   })
 }

--- a/backend/src/api/games/games.controller.ts
+++ b/backend/src/api/games/games.controller.ts
@@ -139,6 +139,7 @@ export const CreatedGame = z.object({
   name: z.string(),
   id: z.number(),
   createdByPlayerId: z.number(),
+  winnerPlayerId: z.number().nullable(),
   nbSeats: z.number(),
   tickIntervalSeconds: z.number(),
   createdAt: z.date(),
@@ -163,6 +164,7 @@ export type GameSummary = z.infer<typeof GameSummary>
 export const GameSummary = z.object({
   name: z.string(),
   id: z.number(),
+  winnerPlayerId: z.number().nullable(),
   nbSeats: z.number(),
   tickIntervalSeconds: z.number(),
   createdAt: z.date(),

--- a/backend/src/api/types.ts
+++ b/backend/src/api/types.ts
@@ -14,3 +14,7 @@ type GamesOutput = TrpcRouterOutput["games"]["getSummaries"]
 export type GameSummary = GamesOutput["games"][number]
 export type GameSummaryStatus = GameSummary["status"]
 export type GameSummaryPlayer = GameSummary["creator"]
+
+// Game player actions router
+type GamePlayerActionsOutput = TrpcRouterOutput["gamePlayerActions"]["getCurrent"]
+export type GamePlayerAction = NonNullable<GamePlayerActionsOutput["action"]>

--- a/backend/src/api/types.ts
+++ b/backend/src/api/types.ts
@@ -16,5 +16,5 @@ export type GameSummaryStatus = GameSummary["status"]
 export type GameSummaryPlayer = GameSummary["creator"]
 
 // Game player actions router
-type GamePlayerActionsOutput = TrpcRouterOutput["gamePlayerActions"]["getCurrent"]
+type GamePlayerActionsOutput = TrpcRouterOutput["gamePlayerActions"]["getCurrentAction"]
 export type GamePlayerAction = NonNullable<GamePlayerActionsOutput["action"]>

--- a/backend/src/lib/db/gamePlayerActions.repository.ts
+++ b/backend/src/lib/db/gamePlayerActions.repository.ts
@@ -104,11 +104,7 @@ export class GamePlayerActionsRepository extends PostgresRepository {
     return Result.Success(getResult.value.map(toGamePlayerActionRow))
   }
 
-  public async deleteByGameIdPlayerIdAndTick(params: {
-    gameId: number
-    playerId: number
-    tick: number
-  }): Promise<Result<true, string>> {
+  public async deleteByGameIdPlayerIdAndTick(params: { gameId: number; playerId: number; tick: number }): Promise<Result<true, string>> {
     const deleteResult = await Result.tryCatch(async (): Promise<true> => {
       await this.db
         .delete(gamePlayerActionsTable)

--- a/backend/src/lib/db/gamePlayerActions.repository.ts
+++ b/backend/src/lib/db/gamePlayerActions.repository.ts
@@ -1,0 +1,106 @@
+import { PostgresRepository } from "./PostgresRepository.ts"
+import { gamePlayerActionsTable } from "./schema.ts"
+import { and, eq } from "drizzle-orm"
+import { Assert, type Logger, Result } from "@guillaume-docquier/tools-ts"
+import { couldNot } from "#lib/errors.ts"
+import { type GamePlayerActionType } from "#lib/gamePlayerActions.ts"
+
+export type GamePlayerActionRow = Omit<typeof gamePlayerActionsTable.$inferSelect, "actionType"> & {
+  actionType: GamePlayerActionType
+}
+
+function toGamePlayerActionRow(gamePlayerActionRow: typeof gamePlayerActionsTable.$inferSelect): GamePlayerActionRow {
+  return {
+    ...gamePlayerActionRow,
+    actionType: gamePlayerActionRow.actionType as GamePlayerActionType,
+  }
+}
+
+export class GamePlayerActionsRepository extends PostgresRepository {
+  private readonly logger: Logger
+
+  public constructor({ logger, db }: { logger: Logger; db: PostgresRepository["db"] }) {
+    super({ db })
+    this.logger = logger.child({ scope: "game-player-actions-repository" })
+  }
+
+  public async upsert(params: {
+    gameId: number
+    playerId: number
+    tick: number
+    actionType: GamePlayerActionType
+  }): Promise<Result<GamePlayerActionRow, string>> {
+    const upsertResult = await Result.tryCatch(async () => {
+      const updatedAt = new Date()
+      const gamePlayerActions = await this.db
+        .insert(gamePlayerActionsTable)
+        .values({ ...params, updatedAt })
+        .onConflictDoUpdate({
+          target: [gamePlayerActionsTable.gameId, gamePlayerActionsTable.playerId, gamePlayerActionsTable.tick],
+          set: {
+            actionType: params.actionType,
+            updatedAt,
+          },
+        })
+        .returning()
+
+      Assert.isTrue(gamePlayerActions.length === 1)
+      Assert.isDefined(gamePlayerActions[0])
+
+      return toGamePlayerActionRow(gamePlayerActions[0])
+    })
+
+    if (Result.isFailure(upsertResult)) {
+      this.logger.error("Could not upsert game player action", { ...params, error: upsertResult.error })
+      return Result.Failure(couldNot("upsert game player action"))
+    }
+
+    return upsertResult
+  }
+
+  public async getByGameIdPlayerIdAndTick(params: {
+    gameId: number
+    playerId: number
+    tick: number
+  }): Promise<Result<GamePlayerActionRow | undefined, string>> {
+    const getResult = await Result.tryCatch(
+      async () =>
+        await this.db
+          .select()
+          .from(gamePlayerActionsTable)
+          .where(
+            and(
+              eq(gamePlayerActionsTable.gameId, params.gameId),
+              eq(gamePlayerActionsTable.playerId, params.playerId),
+              eq(gamePlayerActionsTable.tick, params.tick),
+            ),
+          ),
+    )
+
+    if (Result.isFailure(getResult)) {
+      this.logger.error("Could not get game player action", { ...params, error: getResult.error })
+      return Result.Failure(couldNot("get game player action"))
+    }
+
+    Assert.isTrue(getResult.value.length <= 1)
+    const gamePlayerAction = getResult.value[0]
+    return Result.Success(gamePlayerAction === undefined ? undefined : toGamePlayerActionRow(gamePlayerAction))
+  }
+
+  public async getByGameIdAndTick(params: { gameId: number; tick: number }): Promise<Result<GamePlayerActionRow[], string>> {
+    const getResult = await Result.tryCatch(
+      async () =>
+        await this.db
+          .select()
+          .from(gamePlayerActionsTable)
+          .where(and(eq(gamePlayerActionsTable.gameId, params.gameId), eq(gamePlayerActionsTable.tick, params.tick))),
+    )
+
+    if (Result.isFailure(getResult)) {
+      this.logger.error("Could not get game player actions by tick", { ...params, error: getResult.error })
+      return Result.Failure(couldNot("get game player actions by tick"))
+    }
+
+    return Result.Success(getResult.value.map(toGamePlayerActionRow))
+  }
+}

--- a/backend/src/lib/db/gamePlayerActions.repository.ts
+++ b/backend/src/lib/db/gamePlayerActions.repository.ts
@@ -5,16 +5,7 @@ import { Assert, type Logger, Result } from "@guillaume-docquier/tools-ts"
 import { couldNot } from "#lib/errors.ts"
 import { type GamePlayerActionType } from "#lib/gamePlayerActions.ts"
 
-export type GamePlayerActionRow = Omit<typeof gamePlayerActionsTable.$inferSelect, "actionType"> & {
-  actionType: GamePlayerActionType
-}
-
-function toGamePlayerActionRow(gamePlayerActionRow: typeof gamePlayerActionsTable.$inferSelect): GamePlayerActionRow {
-  return {
-    ...gamePlayerActionRow,
-    actionType: gamePlayerActionRow.actionType as GamePlayerActionType,
-  }
-}
+export type GamePlayerActionRow = typeof gamePlayerActionsTable.$inferSelect
 
 export class GamePlayerActionsRepository extends PostgresRepository {
   private readonly logger: Logger
@@ -47,7 +38,7 @@ export class GamePlayerActionsRepository extends PostgresRepository {
       Assert.isTrue(gamePlayerActions.length === 1)
       Assert.isDefined(gamePlayerActions[0])
 
-      return toGamePlayerActionRow(gamePlayerActions[0])
+      return gamePlayerActions[0]
     })
 
     if (Result.isFailure(upsertResult)) {
@@ -83,8 +74,7 @@ export class GamePlayerActionsRepository extends PostgresRepository {
     }
 
     Assert.isTrue(getResult.value.length <= 1)
-    const gamePlayerAction = getResult.value[0]
-    return Result.Success(gamePlayerAction === undefined ? null : toGamePlayerActionRow(gamePlayerAction))
+    return Result.Success(getResult.value[0] ?? null)
   }
 
   public async getByGameIdAndTick(params: { gameId: number; tick: number }): Promise<Result<GamePlayerActionRow[], string>> {
@@ -101,7 +91,7 @@ export class GamePlayerActionsRepository extends PostgresRepository {
       return Result.Failure(couldNot("get game player actions by tick"))
     }
 
-    return Result.Success(getResult.value.map(toGamePlayerActionRow))
+    return Result.Success(getResult.value)
   }
 
   public async deleteByGameIdPlayerIdAndTick(params: { gameId: number; playerId: number; tick: number }): Promise<Result<true, string>> {

--- a/backend/src/lib/db/gamePlayerActions.repository.ts
+++ b/backend/src/lib/db/gamePlayerActions.repository.ts
@@ -103,4 +103,31 @@ export class GamePlayerActionsRepository extends PostgresRepository {
 
     return Result.Success(getResult.value.map(toGamePlayerActionRow))
   }
+
+  public async deleteByGameIdPlayerIdAndTick(params: {
+    gameId: number
+    playerId: number
+    tick: number
+  }): Promise<Result<true, string>> {
+    const deleteResult = await Result.tryCatch(async (): Promise<true> => {
+      await this.db
+        .delete(gamePlayerActionsTable)
+        .where(
+          and(
+            eq(gamePlayerActionsTable.gameId, params.gameId),
+            eq(gamePlayerActionsTable.playerId, params.playerId),
+            eq(gamePlayerActionsTable.tick, params.tick),
+          ),
+        )
+
+      return true
+    })
+
+    if (Result.isFailure(deleteResult)) {
+      this.logger.error("Could not delete game player action", { ...params, error: deleteResult.error })
+      return Result.Failure(couldNot("delete game player action"))
+    }
+
+    return deleteResult
+  }
 }

--- a/backend/src/lib/db/gamePlayerActions.repository.ts
+++ b/backend/src/lib/db/gamePlayerActions.repository.ts
@@ -62,7 +62,7 @@ export class GamePlayerActionsRepository extends PostgresRepository {
     gameId: number
     playerId: number
     tick: number
-  }): Promise<Result<GamePlayerActionRow | undefined, string>> {
+  }): Promise<Result<GamePlayerActionRow | null, string>> {
     const getResult = await Result.tryCatch(
       async () =>
         await this.db
@@ -84,7 +84,7 @@ export class GamePlayerActionsRepository extends PostgresRepository {
 
     Assert.isTrue(getResult.value.length <= 1)
     const gamePlayerAction = getResult.value[0]
-    return Result.Success(gamePlayerAction === undefined ? undefined : toGamePlayerActionRow(gamePlayerAction))
+    return Result.Success(gamePlayerAction === undefined ? null : toGamePlayerActionRow(gamePlayerAction))
   }
 
   public async getByGameIdAndTick(params: { gameId: number; tick: number }): Promise<Result<GamePlayerActionRow[], string>> {

--- a/backend/src/lib/db/games.repository.ts
+++ b/backend/src/lib/db/games.repository.ts
@@ -134,6 +134,21 @@ export class GamesRepository extends PostgresRepository {
     return Result.Success(gamePlayersResult.value.map(({ playerId }) => playerId))
   }
 
+  public async endWithWinner({ gameId, winnerPlayerId }: { gameId: number; winnerPlayerId: number }): Promise<Result<true, string>> {
+    const endResult = await Result.tryCatch(async (): Promise<true> => {
+      await this.db.update(gamesTable).set({ endedAt: new Date(), winnerPlayerId }).where(eq(gamesTable.id, gameId))
+
+      return true
+    })
+
+    if (Result.isFailure(endResult)) {
+      this.logger.error("Could not end game with winner", { gameId, winnerPlayerId, error: endResult.error })
+      return Result.Failure(couldNot("end game with winner"))
+    }
+
+    return endResult
+  }
+
   private async getSummaryByIdInternal(
     { gameId }: Parameters<GamesRepository["getSummaryById"]>[0],
     dbOrTx: PostgresRepository["db"],

--- a/backend/src/lib/db/schema.ts
+++ b/backend/src/lib/db/schema.ts
@@ -25,6 +25,7 @@ export const gamesTable = pgTable("games", {
   createdByPlayerId: integer()
     .notNull()
     .references(() => playersTable.id, { onDelete: "cascade" }),
+  winnerPlayerId: integer().references(() => playersTable.id, { onDelete: "set null" }),
   nbSeats: integer().notNull(),
   tickIntervalSeconds: integer().notNull(),
   createdAt: timestamp().defaultNow().notNull(),
@@ -88,6 +89,32 @@ export const gameStatesTable = pgTable("game_states", {
   tick: integer().notNull().default(0),
   nextTickAt: timestamp().notNull(),
 })
+
+/**
+ * Player actions selected for a specific game tick.
+ * Rows are kept as append-only history across ticks.
+ */
+export const gamePlayerActionsTable = pgTable(
+  "game_player_actions",
+  {
+    gameId: integer().notNull(),
+    playerId: integer().notNull(),
+    tick: integer().notNull(),
+    actionType: varchar({ length: 255 }).notNull(),
+    createdAt: timestamp().defaultNow().notNull(),
+    updatedAt: timestamp().defaultNow().notNull(),
+  },
+  (table) => [
+    primaryKey({
+      columns: [table.gameId, table.playerId, table.tick],
+    }),
+    foreignKey({
+      columns: [table.gameId, table.playerId],
+      foreignColumns: [gamePlayersTable.gameId, gamePlayersTable.playerId],
+      name: "game_player_actions_gameId_playerId_game_players_fk",
+    }).onDelete("cascade"),
+  ],
+)
 
 /**
  * The state of tick computation

--- a/backend/src/lib/gamePlayerActions.ts
+++ b/backend/src/lib/gamePlayerActions.ts
@@ -1,12 +1,17 @@
 import z from "zod"
+import type { Enumify } from "@guillaume-docquier/tools-ts"
 
+export type GamePlayerActionType = Enumify<typeof GamePlayerActionType>
 export const GamePlayerActionType = {
   MAKE_MORE_MONEY: "MAKE_MORE_MONEY",
   WIN_THE_GAME: "WIN_THE_GAME",
 } as const
 
-export type GamePlayerActionType = (typeof GamePlayerActionType)[keyof typeof GamePlayerActionType]
-
+type PlayerActionRule = {
+  costMoney: number
+  rewardMoney: number
+  endsGame: boolean
+}
 export const GAME_PLAYER_ACTION_RULES = {
   [GamePlayerActionType.MAKE_MORE_MONEY]: {
     costMoney: 2,
@@ -18,19 +23,12 @@ export const GAME_PLAYER_ACTION_RULES = {
     rewardMoney: 0,
     endsGame: true,
   },
-} as const satisfies Record<
-  GamePlayerActionType,
-  {
-    costMoney: number
-    rewardMoney: number
-    endsGame: boolean
-  }
->
+} as const satisfies Record<GamePlayerActionType, PlayerActionRule>
 
 export const GamePlayerActionTypeSchema = z.enum(GamePlayerActionType)
 
-export type GamePlayerAction = z.infer<typeof GamePlayerAction>
-export const GamePlayerAction = z.object({
+export type GamePlayerAction = z.infer<typeof GamePlayerActionSchema>
+export const GamePlayerActionSchema = z.object({
   gameId: z.number(),
   playerId: z.number(),
   tick: z.number(),

--- a/backend/src/lib/gamePlayerActions.ts
+++ b/backend/src/lib/gamePlayerActions.ts
@@ -1,0 +1,39 @@
+import z from "zod"
+
+export const GamePlayerActionType = {
+  MAKE_MORE_MONEY: "MAKE_MORE_MONEY",
+  WIN_THE_GAME: "WIN_THE_GAME",
+} as const
+
+export type GamePlayerActionType = (typeof GamePlayerActionType)[keyof typeof GamePlayerActionType]
+
+export const GAME_PLAYER_ACTION_RULES = {
+  [GamePlayerActionType.MAKE_MORE_MONEY]: {
+    costMoney: 2,
+    rewardMoney: 5,
+    endsGame: false,
+  },
+  [GamePlayerActionType.WIN_THE_GAME]: {
+    costMoney: 10,
+    rewardMoney: 0,
+    endsGame: true,
+  },
+} as const satisfies Record<
+  GamePlayerActionType,
+  {
+    costMoney: number
+    rewardMoney: number
+    endsGame: boolean
+  }
+>
+
+export const GamePlayerActionTypeSchema = z.enum(GamePlayerActionType)
+
+export type GamePlayerAction = z.infer<typeof GamePlayerAction>
+export const GamePlayerAction = z.object({
+  gameId: z.number(),
+  playerId: z.number(),
+  tick: z.number(),
+  actionType: GamePlayerActionTypeSchema,
+  updatedAt: z.date(),
+})

--- a/backend/src/tick-processing/entry.tick-processing.ts
+++ b/backend/src/tick-processing/entry.tick-processing.ts
@@ -8,6 +8,7 @@ import { GameTicksRepository } from "#lib/db/gameTicks.repository.ts"
 import { GameStatesRepository } from "#lib/db/gameStates.repository.ts"
 import { GamePlayerResourcesRepository } from "#lib/db/gamePlayerResources.repository.ts"
 import { GamesRepository } from "#lib/db/games.repository.ts"
+import { GamePlayerActionsRepository } from "#lib/db/gamePlayerActions.repository.ts"
 
 /**
  * Starts tick processing.
@@ -48,6 +49,7 @@ if (!isMainThread) {
     gameTicksRepository: new GameTicksRepository({ db, logger }),
     gameStatesRepository: new GameStatesRepository({ db, logger }),
     gamePlayerResourcesRepository: new GamePlayerResourcesRepository({ db, logger }),
+    gamePlayerActionsRepository: new GamePlayerActionsRepository({ db, logger }),
   }
 
   logger.info("Processing ticks")

--- a/backend/src/tick-processing/processTick.ts
+++ b/backend/src/tick-processing/processTick.ts
@@ -88,7 +88,7 @@ export async function processTick({
         continue
       }
 
-      const actionRule = GAME_PLAYER_ACTION_RULES[selectedAction.actionType]
+      const actionRule = GAME_PLAYER_ACTION_RULES[selectedAction.actionType as GamePlayerActionType] // probably would want to validate this, or store in db as enum
       if (actionRule === undefined) {
         logger.error("Encountered unsupported action type while processing tick", {
           gameTick,

--- a/backend/src/tick-processing/processTick.ts
+++ b/backend/src/tick-processing/processTick.ts
@@ -4,6 +4,8 @@ import { type GameStatesRepository } from "#lib/db/gameStates.repository.ts"
 import { type GamePlayerResourcesRepository } from "#lib/db/gamePlayerResources.repository.ts"
 import { type GamesRepository } from "#lib/db/games.repository.ts"
 import { ResourceType } from "#lib/gameResources.ts"
+import { GAME_PLAYER_ACTION_RULES, GamePlayerActionType } from "#lib/gamePlayerActions.ts"
+import { type GamePlayerActionsRepository } from "#lib/db/gamePlayerActions.repository.ts"
 
 /**
  * Processes all ticks that should advance at this point in time.
@@ -15,12 +17,14 @@ export async function processTick({
   gameStatesRepository,
   gamePlayerResourcesRepository,
   gamesRepository,
+  gamePlayerActionsRepository,
 }: {
   logger: Logger
   gameTicksRepository: GameTicksRepository
   gameStatesRepository: GameStatesRepository
   gamePlayerResourcesRepository: GamePlayerResourcesRepository
   gamesRepository: GamesRepository
+  gamePlayerActionsRepository: GamePlayerActionsRepository
 }): Promise<void> {
   // Lock the tables, can't update state or submit actions during ticks
 
@@ -54,7 +58,16 @@ export async function processTick({
       continue
     }
 
-    let couldNotIncrementPlayersMoney = false
+    const gamePlayerActionsResult = await gamePlayerActionsRepository.getByGameIdAndTick({ gameId: game.id, tick: gameState.tick })
+    if (Result.isFailure(gamePlayerActionsResult)) {
+      logger.error("Could not get game player actions while processing tick", { gameTick, error: gamePlayerActionsResult.error })
+      continue
+    }
+
+    const gamePlayerActionByPlayerId = new Map(gamePlayerActionsResult.value.map((gamePlayerAction) => [gamePlayerAction.playerId, gamePlayerAction]))
+
+    let couldNotProcessPlayers = false
+    let winnerPlayerId: number | undefined
     for (const playerId of playerIdsResult.value) {
       const incrementMoneyResult = await gamePlayerResourcesRepository.updateResource({
         gameId: game.id,
@@ -64,31 +77,85 @@ export async function processTick({
       })
       if (Result.isFailure(incrementMoneyResult)) {
         logger.error("Could not increment player money", { playerId, gameTick, error: incrementMoneyResult.error })
-        couldNotIncrementPlayersMoney = true
+        couldNotProcessPlayers = true
+        break
+      }
+
+      const selectedAction = gamePlayerActionByPlayerId.get(playerId)
+      if (selectedAction === undefined) {
+        continue
+      }
+
+      const actionRule = GAME_PLAYER_ACTION_RULES[selectedAction.actionType]
+      if (actionRule === undefined) {
+        logger.error("Encountered unsupported action type while processing tick", { gameTick, playerId, actionType: selectedAction.actionType })
+        couldNotProcessPlayers = true
+        break
+      }
+
+      const subtractActionCostResult = await gamePlayerResourcesRepository.updateResource({
+        gameId: game.id,
+        playerId,
+        resourceType: ResourceType.MONEY,
+        amountDelta: -actionRule.costMoney,
+      })
+      if (Result.isFailure(subtractActionCostResult)) {
+        logger.error("Could not subtract action cost", { playerId, gameTick, actionType: selectedAction.actionType, error: subtractActionCostResult.error })
+        couldNotProcessPlayers = true
+        break
+      }
+
+      if (selectedAction.actionType === GamePlayerActionType.MAKE_MORE_MONEY) {
+        const addActionRewardResult = await gamePlayerResourcesRepository.updateResource({
+          gameId: game.id,
+          playerId,
+          resourceType: ResourceType.MONEY,
+          amountDelta: actionRule.rewardMoney,
+        })
+        if (Result.isFailure(addActionRewardResult)) {
+          logger.error("Could not add action reward", { playerId, gameTick, actionType: selectedAction.actionType, error: addActionRewardResult.error })
+          couldNotProcessPlayers = true
+          break
+        }
+
+        continue
+      }
+
+      if (selectedAction.actionType === GamePlayerActionType.WIN_THE_GAME) {
+        const endGameResult = await gamesRepository.endWithWinner({ gameId: game.id, winnerPlayerId: playerId })
+        if (Result.isFailure(endGameResult)) {
+          logger.error("Could not end game with winner", { playerId, gameTick, error: endGameResult.error })
+          couldNotProcessPlayers = true
+        } else {
+          winnerPlayerId = playerId
+        }
+
         break
       }
     }
-    if (couldNotIncrementPlayersMoney) {
+    if (couldNotProcessPlayers) {
       continue
     }
 
-    const createGameTickResult = await gameTicksRepository.create({
-      gameId: gameTick.gameId,
-      tick: nextTick,
-      scheduledFor: nextScheduledFor,
-    })
-    if (Result.isFailure(createGameTickResult)) {
-      logger.error("Could not create next game tick", { gameTick, nextTick, nextScheduledFor, error: createGameTickResult.error })
-      continue
-    }
+    if (winnerPlayerId === undefined) {
+      const createGameTickResult = await gameTicksRepository.create({
+        gameId: gameTick.gameId,
+        tick: nextTick,
+        scheduledFor: nextScheduledFor,
+      })
+      if (Result.isFailure(createGameTickResult)) {
+        logger.error("Could not create next game tick", { gameTick, nextTick, nextScheduledFor, error: createGameTickResult.error })
+        continue
+      }
 
-    const updateGameStateResult = await gameStatesRepository.update(
-      { gameId: gameState.gameId },
-      { tick: nextTick, nextTickAt: nextScheduledFor },
-    )
-    if (Result.isFailure(updateGameStateResult)) {
-      logger.error("Could not update game state", { gameState, nextTick, nextScheduledFor, error: updateGameStateResult.error })
-      continue
+      const updateGameStateResult = await gameStatesRepository.update(
+        { gameId: gameState.gameId },
+        { tick: nextTick, nextTickAt: nextScheduledFor },
+      )
+      if (Result.isFailure(updateGameStateResult)) {
+        logger.error("Could not update game state", { gameState, nextTick, nextScheduledFor, error: updateGameStateResult.error })
+        continue
+      }
     }
 
     const finishProcessingTickResult = await gameTicksRepository.finishProcessingTick(gameTick)

--- a/backend/src/tick-processing/processTick.ts
+++ b/backend/src/tick-processing/processTick.ts
@@ -64,7 +64,9 @@ export async function processTick({
       continue
     }
 
-    const gamePlayerActionByPlayerId = new Map(gamePlayerActionsResult.value.map((gamePlayerAction) => [gamePlayerAction.playerId, gamePlayerAction]))
+    const gamePlayerActionByPlayerId = new Map(
+      gamePlayerActionsResult.value.map((gamePlayerAction) => [gamePlayerAction.playerId, gamePlayerAction]),
+    )
 
     let couldNotProcessPlayers = false
     let winnerPlayerId: number | undefined
@@ -88,7 +90,11 @@ export async function processTick({
 
       const actionRule = GAME_PLAYER_ACTION_RULES[selectedAction.actionType]
       if (actionRule === undefined) {
-        logger.error("Encountered unsupported action type while processing tick", { gameTick, playerId, actionType: selectedAction.actionType })
+        logger.error("Encountered unsupported action type while processing tick", {
+          gameTick,
+          playerId,
+          actionType: selectedAction.actionType,
+        })
         couldNotProcessPlayers = true
         break
       }
@@ -100,7 +106,12 @@ export async function processTick({
         amountDelta: -actionRule.costMoney,
       })
       if (Result.isFailure(subtractActionCostResult)) {
-        logger.error("Could not subtract action cost", { playerId, gameTick, actionType: selectedAction.actionType, error: subtractActionCostResult.error })
+        logger.error("Could not subtract action cost", {
+          playerId,
+          gameTick,
+          actionType: selectedAction.actionType,
+          error: subtractActionCostResult.error,
+        })
         couldNotProcessPlayers = true
         break
       }
@@ -113,7 +124,12 @@ export async function processTick({
           amountDelta: actionRule.rewardMoney,
         })
         if (Result.isFailure(addActionRewardResult)) {
-          logger.error("Could not add action reward", { playerId, gameTick, actionType: selectedAction.actionType, error: addActionRewardResult.error })
+          logger.error("Could not add action reward", {
+            playerId,
+            gameTick,
+            actionType: selectedAction.actionType,
+            error: addActionRewardResult.error,
+          })
           couldNotProcessPlayers = true
           break
         }

--- a/frontend/src/routes/games.$gameId.tsx
+++ b/frontend/src/routes/games.$gameId.tsx
@@ -60,6 +60,7 @@ function Game({ game }: { game: ApiTypes.GameSummary }): ReactElement {
       <div className="flex flex-col gap-2 rounded border p-2">
         <div>Id: #{game.id}</div>
         <div>Name: {game.name}</div>
+        {game.winnerPlayerId !== null && <div>Winner: {getWinnerLabel(game)}</div>}
         <div>Creator:</div>
         <div className=" pl-2">
           <Player player={game.creator} />
@@ -131,4 +132,14 @@ function Player({ player }: { player: ApiTypes.GameSummaryPlayer }): ReactElemen
       <div>{player.alias ?? `Player ${player.id}`}</div>
     </div>
   )
+}
+
+function getWinnerLabel(game: ApiTypes.GameSummary): string {
+  const winner = [game.creator, ...game.players].find((player) => player.id === game.winnerPlayerId)
+
+  if (winner === undefined) {
+    return `Player ${game.winnerPlayerId}`
+  }
+
+  return winner.alias ?? `Player ${winner.id}`
 }

--- a/frontend/src/routes/play.$gameId.tsx
+++ b/frontend/src/routes/play.$gameId.tsx
@@ -39,9 +39,13 @@ function GameClient(): ReactElement {
     return <Skeleton />
   }
 
-  if (gameQuery.isError || gameStateQuery.isError) {
-    const errorMessage = gameQuery.isError ? gameQuery.error.message : gameStateQuery.error.message
-    logger.error("Could not fetch game", { gameId, error: errorMessage })
+  if (gameQuery.isError) {
+    logger.error("Could not fetch game", { gameId, error: gameQuery.error.message })
+    return <Navigate to="/games" />
+  }
+
+  if (gameStateQuery.isError) {
+    logger.error("Could not fetch game", { gameId, error: gameStateQuery.error.message })
     return <Navigate to="/games" />
   }
 

--- a/frontend/src/routes/play.$gameId.tsx
+++ b/frontend/src/routes/play.$gameId.tsx
@@ -2,9 +2,11 @@ import { createFileRoute, Navigate, redirect } from "@tanstack/react-router"
 import { type ReactElement, useEffect, useState } from "react"
 import { z } from "zod"
 import { useBackendApiClient } from "../contexts/BackendApiClientContext.tsx"
-import { useQuery } from "@tanstack/react-query"
+import { useMutation, useQuery } from "@tanstack/react-query"
 import { Skeleton } from "../design-system/Skeleton.tsx"
 import { useLogger } from "../contexts/LoggerContext.tsx"
+import { privateRoute } from "../privateRoute.ts"
+import type * as ApiTypes from "@api-types"
 
 const paramsSchema = z.object({
   gameId: z.coerce.number(),
@@ -12,6 +14,7 @@ const paramsSchema = z.object({
 
 export const Route = createFileRoute("/play/$gameId")({
   component: GameClient,
+  beforeLoad: privateRoute,
   params: {
     parse: (params) => paramsSchema.parse(params),
   },
@@ -28,8 +31,10 @@ function GameClient(): ReactElement {
   const { gameId } = Route.useParams()
   const backendApiClient = useBackendApiClient()
   const gameStateQuery = useQuery(backendApiClient.gameStates.getById.queryOptions({ gameId }))
+  const currentActionQuery = useQuery(backendApiClient.gamePlayerActions.getCurrent.queryOptions({ gameId }))
+  const setCurrentAction = useMutation(backendApiClient.gamePlayerActions.setCurrent.mutationOptions())
 
-  if (gameStateQuery.isPending) {
+  if (gameStateQuery.isPending || currentActionQuery.isPending) {
     return <Skeleton />
   }
 
@@ -39,14 +44,100 @@ function GameClient(): ReactElement {
   }
 
   const gameState = gameStateQuery.data.gameState
+  const currentAction = currentActionQuery.data?.action ?? null
 
   return (
-    <div className="flex flex-col items-center justify-center">
-      <div>Current tick: {gameState.tick}</div>
-      <div>Money: {gameState.resources.money}</div>
-      <Countdown targetTimestamp={gameState.nextTickAt} />
+    <div className="flex flex-col items-center justify-center p-8">
+      <div className="flex w-full max-w-3xl flex-col gap-6">
+        <div className="rounded-2xl border border-surface-200 bg-surface-100 p-6">
+          <div className="text-sm uppercase tracking-wide text-surface-500">Game #{gameId}</div>
+          <div className="mt-2 text-2xl font-semibold">Current tick: {gameState.tick}</div>
+          <div className="mt-2 text-lg">Money: {gameState.resources.money}</div>
+          <div className="mt-4">
+            <Countdown targetTimestamp={gameState.nextTickAt} />
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-surface-200 bg-surface-100 p-6">
+          <div className="text-xl font-semibold">Choose your action</div>
+          <div className="mt-1 text-surface-500">Your selection applies to tick {gameState.tick} only.</div>
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            {PLAYER_ACTIONS.map((action) => {
+              const isSelected = currentAction?.actionType === action.actionType
+              const disabledReason =
+                currentActionQuery.isError
+                  ? "Actions are currently unavailable."
+                  : gameState.resources.money < action.costMoney
+                    ? `Requires ${action.costMoney} money.`
+                    : undefined
+
+              return (
+                <button
+                  className={`flex cursor-pointer flex-col gap-3 rounded-2xl border p-4 text-left transition ${
+                    isSelected
+                      ? "border-primary-50 bg-surface-tonal-50"
+                      : "border-surface-200 bg-surface-50 hover:border-primary-200"
+                  } disabled:cursor-not-allowed disabled:border-surface-200 disabled:bg-surface-100 disabled:text-surface-500`}
+                  disabled={disabledReason !== undefined || setCurrentAction.isPending}
+                  key={action.actionType}
+                  onClick={() => {
+                    setCurrentAction.mutate({ gameId, actionType: action.actionType })
+                  }}
+                  type="button"
+                >
+                  <div className="flex items-center justify-between gap-4">
+                    <div className="text-lg font-semibold">{action.label}</div>
+                    {isSelected && <div className="text-sm font-semibold uppercase text-primary-200">Selected</div>}
+                  </div>
+                  <div className="text-sm text-surface-500">{action.description}</div>
+                  <div className="text-sm">
+                    Cost: {action.costMoney} money
+                    {action.rewardMoney > 0 ? ` | Effect: +${action.rewardMoney} money after paying the cost` : " | Effect: End the game immediately"}
+                  </div>
+                  {disabledReason !== undefined && <div className="text-sm text-danger-100">{disabledReason}</div>}
+                </button>
+              )
+            })}
+          </div>
+
+          <div className="mt-4 text-sm text-surface-500">
+            Current selection: {currentAction === null ? "No action selected yet." : getActionLabel(currentAction.actionType)}
+          </div>
+          {currentActionQuery.isError && <div className="mt-2 text-sm text-danger-100">{currentActionQuery.error.message}</div>}
+          {setCurrentAction.isError && <div className="mt-2 text-sm text-danger-100">{setCurrentAction.error.message}</div>}
+        </div>
+      </div>
     </div>
   )
+}
+
+const PLAYER_ACTIONS = [
+  {
+    actionType: "MAKE_MORE_MONEY",
+    label: "Make More Money",
+    description: "Turn 2 money into 5 extra money after the normal tick income.",
+    costMoney: 2,
+    rewardMoney: 5,
+  },
+  {
+    actionType: "WIN_THE_GAME",
+    label: "Win The Game",
+    description: "Spend 10 money and immediately end the game in your favor.",
+    costMoney: 10,
+    rewardMoney: 0,
+  },
+] as const satisfies Array<{
+  actionType: ApiTypes.GamePlayerAction["actionType"]
+  label: string
+  description: string
+  costMoney: number
+  rewardMoney: number
+}>
+
+function getActionLabel(actionType: ApiTypes.GamePlayerAction["actionType"]): string {
+  const action = PLAYER_ACTIONS.find((playerAction) => playerAction.actionType === actionType)
+
+  return action?.label ?? actionType
 }
 
 function Countdown({ targetTimestamp }: { targetTimestamp: string }): ReactElement {

--- a/frontend/src/routes/play.$gameId.tsx
+++ b/frontend/src/routes/play.$gameId.tsx
@@ -45,13 +45,18 @@ function GameClient(): ReactElement {
   }
 
   if (gameStateQuery.isError) {
-    logger.error("Could not fetch game", { gameId, error: gameStateQuery.error.message })
+    logger.error("Could not fetch game state", { gameId, error: gameStateQuery.error.message })
+    return <Navigate to="/games" />
+  }
+
+  if (currentActionQuery.isError) {
+    logger.error("Could not fetch current action", { gameId, error: currentActionQuery.error.message })
     return <Navigate to="/games" />
   }
 
   const game = gameQuery.data.game
   const gameState = gameStateQuery.data.gameState
-  const currentAction = currentActionQuery.data?.action ?? null
+  const currentAction = currentActionQuery.data.action
 
   return (
     <div className="flex flex-col items-center justify-center p-8">
@@ -90,6 +95,7 @@ function GameClient(): ReactElement {
                   onClick={() => {
                     setCurrentAction.mutate({
                       gameId,
+                      tick: gameState.tick,
                       actionType: isSelected ? null : action.actionType,
                     })
                   }}
@@ -115,7 +121,6 @@ function GameClient(): ReactElement {
           <div className="mt-4 text-sm text-surface-500">
             Current selection: {currentAction === null ? "No action selected yet." : getActionLabel(currentAction.actionType)}
           </div>
-          {currentActionQuery.isError && <div className="mt-2 text-sm text-danger-100">{currentActionQuery.error.message}</div>}
           {setCurrentAction.isError && <div className="mt-2 text-sm text-danger-100">{setCurrentAction.error.message}</div>}
         </div>
       </div>

--- a/frontend/src/routes/play.$gameId.tsx
+++ b/frontend/src/routes/play.$gameId.tsx
@@ -64,19 +64,16 @@ function GameClient(): ReactElement {
           <div className="mt-4 grid gap-4 md:grid-cols-2">
             {PLAYER_ACTIONS.map((action) => {
               const isSelected = currentAction?.actionType === action.actionType
-              const disabledReason =
-                currentActionQuery.isError
-                  ? "Actions are currently unavailable."
-                  : gameState.resources.money < action.costMoney
-                    ? `Requires ${action.costMoney} money.`
-                    : undefined
+              const disabledReason = currentActionQuery.isError
+                ? "Actions are currently unavailable."
+                : gameState.resources.money < action.costMoney
+                  ? `Requires ${action.costMoney} money.`
+                  : undefined
 
               return (
                 <button
                   className={`flex cursor-pointer flex-col gap-3 rounded-2xl border p-4 text-left transition ${
-                    isSelected
-                      ? "border-primary-50 bg-surface-tonal-50"
-                      : "border-surface-200 bg-surface-50 hover:border-primary-200"
+                    isSelected ? "border-primary-50 bg-surface-tonal-50" : "border-surface-200 bg-surface-50 hover:border-primary-200"
                   } disabled:cursor-not-allowed disabled:border-surface-200 disabled:bg-surface-100 disabled:text-surface-500`}
                   disabled={disabledReason !== undefined || setCurrentAction.isPending}
                   key={action.actionType}
@@ -95,7 +92,9 @@ function GameClient(): ReactElement {
                   <div className="text-sm text-surface-500">{action.description}</div>
                   <div className="text-sm">
                     Cost: {action.costMoney} money
-                    {action.rewardMoney > 0 ? ` | Effect: +${action.rewardMoney} money after paying the cost` : " | Effect: End the game immediately"}
+                    {action.rewardMoney > 0
+                      ? ` | Effect: +${action.rewardMoney} money after paying the cost`
+                      : " | Effect: End the game immediately"}
                   </div>
                   {disabledReason !== undefined && <div className="text-sm text-danger-100">{disabledReason}</div>}
                 </button>

--- a/frontend/src/routes/play.$gameId.tsx
+++ b/frontend/src/routes/play.$gameId.tsx
@@ -30,19 +30,22 @@ function GameClient(): ReactElement {
   const logger = useLogger()
   const { gameId } = Route.useParams()
   const backendApiClient = useBackendApiClient()
+  const gameQuery = useQuery(backendApiClient.games.getSummaryById.queryOptions({ gameId }))
   const gameStateQuery = useQuery(backendApiClient.gameStates.getById.queryOptions({ gameId }))
   const currentActionQuery = useQuery(backendApiClient.gamePlayerActions.getCurrent.queryOptions({ gameId }))
   const setCurrentAction = useMutation(backendApiClient.gamePlayerActions.setCurrent.mutationOptions())
 
-  if (gameStateQuery.isPending || currentActionQuery.isPending) {
+  if (gameQuery.isPending || gameStateQuery.isPending || currentActionQuery.isPending) {
     return <Skeleton />
   }
 
-  if (gameStateQuery.isError) {
-    logger.error("Could not fetch game", { gameId, error: gameStateQuery.error.message })
+  if (gameQuery.isError || gameStateQuery.isError) {
+    const errorMessage = gameQuery.isError ? gameQuery.error.message : gameStateQuery.error.message
+    logger.error("Could not fetch game", { gameId, error: errorMessage })
     return <Navigate to="/games" />
   }
 
+  const game = gameQuery.data.game
   const gameState = gameStateQuery.data.gameState
   const currentAction = currentActionQuery.data?.action ?? null
 
@@ -51,6 +54,9 @@ function GameClient(): ReactElement {
       <div className="flex w-full max-w-3xl flex-col gap-6">
         <div className="rounded-2xl border border-surface-200 bg-surface-100 p-6">
           <div className="text-sm uppercase tracking-wide text-surface-500">Game #{gameId}</div>
+          {game.winnerPlayerId !== null && (
+            <div className="mt-2 text-lg font-semibold text-success-100">Winner: {getWinnerLabel(game)}</div>
+          )}
           <div className="mt-2 text-2xl font-semibold">Current tick: {gameState.tick}</div>
           <div className="mt-2 text-lg">Money: {gameState.resources.money}</div>
           <div className="mt-4">
@@ -140,6 +146,16 @@ function getActionLabel(actionType: ApiTypes.GamePlayerAction["actionType"]): st
   const action = PLAYER_ACTIONS.find((playerAction) => playerAction.actionType === actionType)
 
   return action?.label ?? actionType
+}
+
+function getWinnerLabel(game: ApiTypes.GameSummary): string {
+  const winner = [game.creator, ...game.players].find((player) => player.id === game.winnerPlayerId)
+
+  if (winner === undefined) {
+    return `Player ${game.winnerPlayerId}`
+  }
+
+  return winner.alias ?? `Player ${winner.id}`
 }
 
 function Countdown({ targetTimestamp }: { targetTimestamp: string }): ReactElement {

--- a/frontend/src/routes/play.$gameId.tsx
+++ b/frontend/src/routes/play.$gameId.tsx
@@ -32,8 +32,8 @@ function GameClient(): ReactElement {
   const backendApiClient = useBackendApiClient()
   const gameQuery = useQuery(backendApiClient.games.getSummaryById.queryOptions({ gameId }))
   const gameStateQuery = useQuery(backendApiClient.gameStates.getById.queryOptions({ gameId }))
-  const currentActionQuery = useQuery(backendApiClient.gamePlayerActions.getCurrent.queryOptions({ gameId }))
-  const setCurrentAction = useMutation(backendApiClient.gamePlayerActions.setCurrent.mutationOptions())
+  const currentActionQuery = useQuery(backendApiClient.gamePlayerActions.getCurrentAction.queryOptions({ gameId }))
+  const setCurrentAction = useMutation(backendApiClient.gamePlayerActions.setCurrentAction.mutationOptions())
 
   if (gameQuery.isPending || gameStateQuery.isPending || currentActionQuery.isPending) {
     return <Skeleton />
@@ -173,7 +173,7 @@ function Countdown({ targetTimestamp }: { targetTimestamp: string }): ReactEleme
 
     return (): void => {
       clearInterval(interval)
-    } // cleanup
+    }
   }, [targetTimestamp])
 
   if (timeLeft.noTimeLeft) {
@@ -198,7 +198,7 @@ function calculateTimeLeft(config: { past: Date; future: Date }): TimeLeft {
   const past = Temporal.Instant.fromEpochMilliseconds(config.past.getTime())
   const future = Temporal.Instant.fromEpochMilliseconds(config.future.getTime())
 
-  const duration = future.since(past).round({ largestUnit: "days" })
+  const duration = past.until(future).round({ largestUnit: "days" })
 
   return {
     noTimeLeft: duration.total("seconds") <= 0,

--- a/frontend/src/routes/play.$gameId.tsx
+++ b/frontend/src/routes/play.$gameId.tsx
@@ -81,7 +81,10 @@ function GameClient(): ReactElement {
                   disabled={disabledReason !== undefined || setCurrentAction.isPending}
                   key={action.actionType}
                   onClick={() => {
-                    setCurrentAction.mutate({ gameId, actionType: action.actionType })
+                    setCurrentAction.mutate({
+                      gameId,
+                      actionType: isSelected ? null : action.actionType,
+                    })
                   }}
                   type="button"
                 >


### PR DESCRIPTION
## Issue
- fixes https://github.com/Guillaume-Docquier/text-based-browser-game-1/issues/66

## Description

Added player actions:
- make more money
- win the game

Actions are stored per tick and can be changed at any time
Actions are reset after a tick

Winner is shown when the game is won

<img width="925" height="731" alt="image" src="https://github.com/user-attachments/assets/eccaf907-9e20-4949-a181-09936b92b99e" />

<details>

<summary>Codex Implementation Plan</summary>

# Player Actions V1

## Summary

Add per-player, per-game action selection for active games with two actions: `MAKE_MORE_MONEY` and `WIN_THE_GAME`. Players choose at most one action for the upcoming tick from the play screen, can change it any time before processing starts, and their current selection persists across page refreshes. Tick processing resolves the selected action for the current tick without deleting historical action rows.

Chosen product rules for this plan:

- Ticks keep the existing passive `+1 money`.
- Action submission is rejected unless the player can already afford the action at submit time.
- Current selections are private to the current player only.
- Winning must persist the winner.

## Implementation Phases

### Phase 1: Data model and backend primitives

1. Add `winnerPlayerId` to `games` and add the append-only `game_player_actions` table keyed by `(gameId, playerId, tick)`.
2. Update Drizzle schema, inferred row types, and migration files for both schema changes.
3. Add backend action constants and types for:
   - action ids
   - action cost/reward rules
   - shared Zod schema for API output
4. Add repository methods to:
   - upsert one action for `(gameId, playerId, tick)`
   - fetch one action for `(gameId, playerId, tick)`
   - fetch all actions for `(gameId, tick)`

### Phase 2: API and business rules

1. Add a `gamePlayerActions` controller following the existing controller pattern.
2. In action submission, resolve the game’s current tick from `game_states`.
3. Enforce submission rules:
   - game exists
   - game is started
   - game is not ended
   - player belongs to the game
   - player can afford the selected action now
4. Add tRPC routes:
   - `getCurrent({ gameId })`
   - `setCurrent({ gameId, actionType })`
5. Register the router in `createApi.ts` and expose any required frontend API types.

### Phase 3: Tick resolution

1. Extend tick processing to fetch all actions for `(gameId, gameState.tick)` before resolving players.
2. Keep the existing passive `+1 money` income.
3. Resolve submitted actions for that tick:
   - `MAKE_MORE_MONEY`: `-2 money`, then `+5 money`
   - `WIN_THE_GAME`: `-10 money`, set `endedAt`, set `winnerPlayerId`
4. If a player wins:
   - finish the current tick
   - do not schedule the next tick
   - leave existing action rows untouched
5. If no player wins:
   - schedule the next tick as today
   - update `game_states` to the next tick
   - leave existing action rows untouched

### Phase 4: Frontend play screen

1. Extend `/play/$gameId` to fetch both the player game state and the current action for the current tick.
2. Add a basic action selection UI with two choices:
   - `Make More Money`
   - `Win The Game`
3. Show the currently selected action and its cost/effect.
4. Disable unavailable actions when the player lacks money and show an inline reason.
5. Submit selection changes through the new mutation and refresh the current-action query so refreshes remain consistent.
6. After tick advancement, show no current selection for the new tick until the player picks again.

### Phase 5: Verification

1. Run repository-level checks for append-only per-tick action behavior.
2. Run controller/router checks for membership, game lifecycle, and affordability rules.
3. Run tick-processing checks for normal income, action resolution, and win handling.
4. Run frontend manual verification on refresh persistence, selection changes, and post-tick empty state.

## Implementation Changes

### Data model

- Add a new `game_player_actions` table keyed by `(gameId, playerId, tick)` with:
  - `gameId`
  - `playerId`
  - `tick`
  - `actionType`
  - `createdAt`
  - `updatedAt`
- Treat this table as append-only history. A player’s current action is the row for the game’s current tick, and changing the action before processing updates that same `(gameId, playerId, tick)` row.
- Add a `winnerPlayerId` nullable FK on `games` so ended games can persist the winner.
- Keep action costs and rewards in backend constants, using the existing `as const` pattern:
  - `MAKE_MORE_MONEY`: cost `2 MONEY`, reward `5 MONEY`
  - `WIN_THE_GAME`: cost `10 MONEY`, ends the game, no resource reward
- Generate a migration for both schema changes and update Drizzle schema/types accordingly.
- Add a uniqueness guarantee via the primary key so each player has at most one action row per game tick.

### Backend API and business logic

- Add a dedicated player-actions backend slice following the existing router/controller/repository pattern.
- Repository responsibilities:
  - upsert the current player action for `(gameId, playerId, tick)`
  - fetch the current player action for `(gameId, playerId, tick)`
  - fetch all actions for `(gameId, tick)` during tick processing
- Controller responsibilities:
  - verify the game exists and is started but not ended
  - verify the player belongs to the game
  - resolve the game’s current tick from `game_states` and always submit against that tick
  - verify affordability at submission time using current resources
  - map DB rows to API types
- tRPC routes:
  - `gamePlayerActions.getCurrent({ gameId }) -> { action: GamePlayerAction | null }`
  - `gamePlayerActions.setCurrent({ gameId, actionType }) -> { action: GamePlayerAction }`
- Add the new router to `createApi.ts` and export any needed frontend API types.

### Tick processing

- Extend `processTick` to load all selected actions for `(gameId, gameState.tick)` before resolving players.
- Per player, resolve in this order:
  1. apply the existing passive `+1 MONEY`
  2. if no selected action, continue
  3. if selected action is `MAKE_MORE_MONEY`, subtract `2 MONEY` then add `5 MONEY`
  4. if selected action is `WIN_THE_GAME`, subtract `10 MONEY`, mark the game ended, and set `winnerPlayerId`
- Since submission already enforces affordability, tick processing can treat selected actions as executable invariants; if data is inconsistent, log and fail that tick rather than silently changing behavior.
- When a winning action succeeds:
  - update `games.endedAt` and `games.winnerPlayerId`
  - do not schedule another tick for that game
  - still mark the current tick as finished
- For non-winning ticks:
  - preserve current next-tick scheduling/state update behavior
  - do not delete or clear any action rows; the next tick naturally reads a different `(gameId, tick)` slice
- For non-winning ticks:
  - preserve current next-tick scheduling/state update behavior
- Keep the implementation dependency-injected and `Result`-based, with no new module-scope state.

### Frontend

- Extend the `/play/$gameId` page to fetch both:
  - current game state
  - current player action
- Add a basic action menu on the play screen, colocated with current tick/resources, with:
  - a button or simple selectable card for `Make More Money`
  - a button or simple selectable card for `Win The Game`
  - disabled state and inline reason when the current money is below the action cost
  - visible indication of the currently selected action
- Mutating the selection should refresh the current action query so a page refresh shows the persisted choice.
- After a tick processes and actions are reset, the page should show no selected action on the next successful refetch.
- After a tick processes, the page should show no selected action for the new current tick unless the player chooses another one.
- If winner persistence is surfaced in existing game summary/status views, show ended state consistently; winner display on the frontend can be limited to the play page or deferred unless already needed by the changed screens.

## Detailed Steps

### Step 1: Schema and types

- Add `winnerPlayerId` to `gamesTable` with a nullable FK to `playersTable`.
- Add `gamePlayerActionsTable` with `gameId`, `playerId`, `tick`, `actionType`, `createdAt`, and `updatedAt`.
- Use FK constraints back to the game/player membership shape so action rows stay tied to valid game participants.
- Update generated migration artifacts and any inferred repository row types.

### Step 2: Action domain model

- Add a backend module for player action constants using the repo’s `as const` pattern.
- Define the supported action ids and their cost/effect metadata in one place.
- Add a Zod schema and exported type for `GamePlayerAction`.

### Step 3: Repository layer

- Create a `GamePlayerActionsRepository`.
- Implement upsert-by-primary-key for `(gameId, playerId, tick)`.
- Implement `getByGameIdPlayerIdAndTick`.
- Implement `getByGameIdAndTick`.
- Keep all DB access isolated in this repository.

### Step 4: Controller layer

- Create a `GamePlayerActionsController`.
- On `setCurrent`, fetch the player’s current game state to obtain the active tick and current money.
- Reject writes when the game state does not exist, the player is not in the game, the game has ended, or the action is unaffordable.
- Return the persisted action row mapped to the API schema.
- On `getCurrent`, read the current tick first and then fetch the action for that tick only.

### Step 5: Router integration

- Add `gamePlayerActions.router.ts`.
- Add private procedures for `getCurrent` and `setCurrent`.
- Keep the same DI and return-type pattern as the existing routers.
- Register the new router namespace in `createApi.ts`.
- Export any frontend-consumed output types if needed.

### Step 6: Tick-processing integration

- Inject `GamePlayerActionsRepository` into the tick-processing entrypoint and `processTick`.
- For each game tick being processed, fetch actions by `(gameId, gameState.tick)` once before looping players.
- Match actions to players during resolution.
- Preserve the current money increment behavior.
- Apply action effects after the passive income.
- On `WIN_THE_GAME`, persist `endedAt` and `winnerPlayerId`, skip next-tick creation, and finish the current tick cleanly.
- Do not delete or mutate historical action rows once the tick is processed.

### Step 7: Frontend integration

- Add frontend usage of the new router methods in `play.$gameId.tsx`.
- Query the current action alongside the existing game-state query.
- Render a minimal action menu with clear selected/unselected states.
- Use a mutation to change the current action and refetch the current-action query on success.
- Keep the UI resilient when no action exists for the current tick.

### Step 8: Verification pass

- Validate append-only DB behavior for multiple ticks.
- Validate that changing the action before processing overwrites only the current tick row.
- Validate that advancing the tick results in no selected action for the new tick.
- Validate that winning ends the game and persists the winner.

## Public Interfaces / Types

- New backend action type enum-like constant and Zod schema for `GamePlayerAction`.
- New tRPC router namespace: `gamePlayerActions`.
- New API payload shape:
  - `GamePlayerAction = { gameId: number; playerId: number; tick: number; actionType: "MAKE_MORE_MONEY" | "WIN_THE_GAME"; updatedAt: Date }`
- Extend game types as needed to include `winnerPlayerId: number | null` where ended-game winner display is required.

## Test Plan

- DB/repository checks:
  - can upsert an action for a player in a game and tick
  - updating the action replaces the previous selection for the same `(gameId, playerId, tick)` instead of creating duplicates
  - actions for prior ticks remain stored after processing
  - fetching actions by `(gameId, tick)` returns only that tick’s rows
- Controller/router checks:
  - rejects action submission for non-members
  - rejects action submission for not-started or ended games
  - rejects `MAKE_MORE_MONEY` below `2 money`
  - rejects `WIN_THE_GAME` below `10 money`
  - returns persisted current action after refresh/read
- Tick-processing scenarios:
  - no selected action: player still gets `+1 money`
  - `MAKE_MORE_MONEY`: player with `2` money ends tick at `6` (`2 + 1 - 2 + 5`)
  - `WIN_THE_GAME`: player with `10` money ends the game, winner is stored, no next tick is scheduled
  - after a tick advances, the next tick has no current selection until a new row is submitted for that new tick
- Manual verification:
  - select action on `/play/$gameId`, refresh, selection remains
  - change selection before tick, latest choice is the one persisted
  - once the tick passes and data refetches, selection is empty for the new current tick while the old row remains in the database
  - winning action transitions the game to ended state and prevents further play actions

## Assumptions

- Action visibility is private: only the current player can read their own selected action.
- “Hard error on affordability” means affordability is checked at submission time, not deferred to tick resolution.
- `game_player_actions` is the action-history system for v1, but reads and writes only target the current tick unless tick processing is fetching rows to resolve.
- Tick processing remains sequential per game as it is now; this plan does not add broader locking or transactional refactors beyond what is needed for action resolution and reset.


</details>