### PR TITLE
adr: Clarify Zod schema ownership and repository/database naming conventions

### DIFF
--- a/docs/adr/010-router-controller-repository.md
+++ b/docs/adr/010-router-controller-repository.md
@@ -4,6 +4,10 @@
 
 Accepted
 
+### Amendment history
+
+- 2026-05-14: Clarified ownership for Zod schemas and naming conventions for DTOs and repository/database types.
+
 ## Context
 
 Backend needs structure. We have many technologies in play (api, persistence and business logic) and if we're not careful, we'll be coupling everything.
@@ -19,6 +23,19 @@ We'll make sure to decouple each layer, with:
 - Controllers: business logic that bridge routers and repositories.
 
 Repositories represent data access patterns (aka queries) and are not restricted to accessing single tables (think, joins).
+
+### Schema ownership and naming
+
+- Repositories never own Zod schemas. Repositories do not validate user input and should focus on persistence concerns.
+- At the architecture boundary, routers could own request validation schemas. In practice for this codebase, controllers own Zod schemas because it is more practical while keeping responsibilities clear.
+- Controller-owned Zod schemas and related types should be named with the `Dto` suffix (for example: `StarSystemDto`).
+
+Repository and database types should follow these naming conventions:
+
+- Repository creation input types use the `New` prefix (for example: `NewStarSystem`).
+- Repository query result types use the `ReadModel` suffix (for example: `StarSystemReadModel`).
+- Internal database query row shapes use the `Row` suffix (for example: `StarSystemRow`).
+- `Row` types are internal repository implementation details and must never be exported. This keeps database architecture decoupled from the rest of the application.
 
 ## Consequences
 


### PR DESCRIPTION
## Issue

- fixes https://github.com/Guillaume-Docquier/text-based-browser-game-1/issues/155
- fixes 
https://github.com/Guillaume-Docquier/text-based-browser-game-1/issues/156
## Motivation

Make ownership of validation schemas and naming of DTOs/repository types explicit to reduce coupling between API, business logic, and persistence layers.

## Description

Add an amendment to `docs/adr/010-router-controller-repository.md` documenting that repositories never own Zod schemas and that controllers own Zod schemas by default, using the `Dto` suffix (for example: `StarSystemDto`).

Add naming conventions for repository and database types, including `New` prefix for creation inputs (for example: `NewStarSystem`), `ReadModel` suffix for query results (for example: `StarSystemReadModel`), and `Row` suffix for internal database row shapes (for example: `StarSystemRow`).

Clarify that `Row` types are internal to repository implementations and must not be exported, and include an amendment history entry dated `2026-05-14`.

## Testing

Documentation-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05d4ad75f8832db9ca306d9f91b919)