### PR TITLE
frontend: use dedicated frontend API hooks

### DIFF
--- a/frontend/src/features/games/CreateGamePage.tsx
+++ b/frontend/src/features/games/CreateGamePage.tsx
@@ -1,7 +1,5 @@
 import type * as ApiTypes from "@api-types"
 import type { Enumify } from "@guillaume-docquier/tools-ts"
-import { useMutation, useQuery } from "@tanstack/react-query"
-import { useNavigate } from "@tanstack/react-router"
 import { type ReactElement, useState } from "react"
 import { Button } from "../../components/button.tsx"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../components/card.tsx"
@@ -10,7 +8,8 @@ import { Label } from "../../components/label.tsx"
 import { RangeSlider } from "../../components/RangeSlider.tsx"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../components/select.tsx"
 import { Skeleton } from "../../components/skeleton.tsx"
-import { useBackendApiClient } from "../../lib/api/BackendApiClientContext.tsx"
+import { useCreateGameMutation } from "../../lib/api/useCreateGameMutation.ts"
+import { useLobbyCreationSettingsQuery } from "../../lib/api/useLobbyCreationSettingsQuery.ts"
 import { PageHeader } from "../PageHeader.tsx"
 
 type TickIntervalUnit = Enumify<typeof TickIntervalUnit>
@@ -44,13 +43,7 @@ const RANGE_SETTING_LABELS = {
 } satisfies Record<ApiTypes.RangeSettingKey, { label: string; description: string }>
 
 export function CreateGamePage(): ReactElement {
-  const backendApiClient = useBackendApiClient()
-  const creationSettingsQuery = useQuery({
-    ...backendApiClient.lobbies.getCreationSettings.queryOptions(),
-    staleTime: Infinity,
-    gcTime: Infinity,
-    refetchOnMount: "always",
-  })
+  const creationSettingsQuery = useLobbyCreationSettingsQuery()
 
   if (creationSettingsQuery.isPending || creationSettingsQuery.isFetching) {
     return <CreateGameLoadingState />
@@ -73,14 +66,7 @@ function CreateGameForm({ creationSettings }: { creationSettings: ApiTypes.Lobby
   const [tickIntervalMultiplier, setTickIntervalMultiplier] = useState(1)
   const [tickIntervalUnit, setTickIntervalUnit] = useState<TickIntervalUnit>(TickIntervalUnit.days)
   const [starSystemGenerationSettings, setStarSystemGenerationSettings] = useState(creationSettings.defaultStarSystemGenerationSettings)
-  const navigate = useNavigate()
-  const backendApiClient = useBackendApiClient()
-  const createGame = useMutation({
-    ...backendApiClient.lobbies.create.mutationOptions(),
-    onSuccess: async ({ createdGameId }) => {
-      await navigate({ to: "/games/$gameId", params: { gameId: createdGameId } })
-    },
-  })
+  const createGame = useCreateGameMutation()
   const isCreateDisabled = name === "" || nbSeats < 2
 
   return (

--- a/frontend/src/features/games/GamesBrowserPage.tsx
+++ b/frontend/src/features/games/GamesBrowserPage.tsx
@@ -1,5 +1,4 @@
 import type * as ApiTypes from "@api-types"
-import { useQuery } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 import { Search } from "lucide-react"
 import { type ReactElement, useState } from "react"
@@ -8,15 +7,14 @@ import { Button } from "../../components/button.tsx"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../components/card.tsx"
 import { Input } from "../../components/input.tsx"
 import { Skeleton } from "../../components/skeleton.tsx"
-import { useBackendApiClient } from "../../lib/api/BackendApiClientContext.tsx"
+import { useListingsQuery } from "../../lib/api/useListingsQuery.ts"
 import { timeAgo } from "../../lib/timeAgo.ts"
 import { PageHeader } from "../PageHeader.tsx"
 import { GameStatusBadge } from "../play/components/GameStatusBadge.tsx"
 
 export function GamesBrowserPage(): ReactElement {
   const [gameNameFilter, setGameNameFilter] = useState("")
-  const backendApiClient = useBackendApiClient()
-  const listingsQuery = useQuery(backendApiClient.listings.getListings.queryOptions())
+  const listingsQuery = useListingsQuery()
 
   if (listingsQuery.isPending) {
     return <GamesLoadingState />

--- a/frontend/src/features/games/LobbyPage.tsx
+++ b/frontend/src/features/games/LobbyPage.tsx
@@ -1,12 +1,14 @@
 import type * as ApiTypes from "@api-types"
-import { useMutation, useQuery } from "@tanstack/react-query"
 import { Navigate, useNavigate } from "@tanstack/react-router"
 import type { ReactElement } from "react"
 import { Button } from "../../components/button.tsx"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../components/card.tsx"
 import { Separator } from "../../components/separator.tsx"
 import { Skeleton } from "../../components/skeleton.tsx"
-import { useBackendApiClient } from "../../lib/api/BackendApiClientContext.tsx"
+import { useJoinGameMutation } from "../../lib/api/useJoinGameMutation.ts"
+import { useLeaveGameMutation } from "../../lib/api/useLeaveGameMutation.ts"
+import { useLobbyQuery } from "../../lib/api/useLobbyQuery.ts"
+import { useStartGameMutation } from "../../lib/api/useStartGameMutation.ts"
 import { formatLobbyStatus } from "../../lib/formatLobbyStatus.ts"
 import { useLogger } from "../../lib/LoggerContext.tsx"
 import { timeAgo } from "../../lib/timeAgo.ts"
@@ -15,8 +17,7 @@ import { GameStatusBadge } from "../play/components/GameStatusBadge.tsx"
 
 export function LobbyPage({ gameId }: { gameId: ApiTypes.GameId }): ReactElement {
   const logger = useLogger()
-  const backendApiClient = useBackendApiClient()
-  const gameQuery = useQuery(backendApiClient.lobbies.getById.queryOptions({ gameId }))
+  const gameQuery = useLobbyQuery(gameId)
 
   if (gameQuery.isPending) {
     return <LobbyLoadingState />
@@ -36,10 +37,9 @@ export function LobbyPage({ gameId }: { gameId: ApiTypes.GameId }): ReactElement
 
 function Game({ game }: { game: ApiTypes.Lobby }): ReactElement {
   const navigate = useNavigate()
-  const backendApiClient = useBackendApiClient()
-  const joinGame = useMutation(backendApiClient.lobbies.join.mutationOptions())
-  const leaveGame = useMutation(backendApiClient.lobbies.leave.mutationOptions())
-  const startGame = useMutation(backendApiClient.gameplay.startGame.mutationOptions())
+  const joinGame = useJoinGameMutation()
+  const leaveGame = useLeaveGameMutation()
+  const startGame = useStartGameMutation()
 
   return (
     <div className="flex flex-col gap-6">

--- a/frontend/src/features/play/PlayGameLayout.tsx
+++ b/frontend/src/features/play/PlayGameLayout.tsx
@@ -1,17 +1,16 @@
 import type { GameId } from "@api-types"
-import { useQuery } from "@tanstack/react-query"
 import { Navigate, Outlet } from "@tanstack/react-router"
 import type { ReactElement } from "react"
-import { useBackendApiClient } from "../../lib/api/BackendApiClientContext.tsx"
+import { useLobbyQuery } from "../../lib/api/useLobbyQuery.ts"
+import { usePlayerViewQuery } from "../../lib/api/usePlayerViewQuery.ts"
 import { useLogger } from "../../lib/LoggerContext.tsx"
 import { GameLayout, GameLayoutSkeleton } from "./components/GameLayout.tsx"
 import { PlayGameContextProvider, type PlayGameContextValue } from "./PlayContext.tsx"
 
 export function PlayGameLayout({ gameId }: { gameId: GameId }): ReactElement {
   const logger = useLogger()
-  const backendApiClient = useBackendApiClient()
-  const gameQuery = useQuery(backendApiClient.lobbies.getById.queryOptions({ gameId }))
-  const playerViewQuery = useQuery(backendApiClient.gameplay.getPlayerView.queryOptions({ gameId }))
+  const gameQuery = useLobbyQuery(gameId)
+  const playerViewQuery = usePlayerViewQuery(gameId)
 
   if (gameQuery.isPending || playerViewQuery.isPending) {
     return <GameLayoutSkeleton />

--- a/frontend/src/features/play/PlayerActionsPage.tsx
+++ b/frontend/src/features/play/PlayerActionsPage.tsx
@@ -1,9 +1,8 @@
 import type { GameId } from "@api-types"
-import { useQuery } from "@tanstack/react-query"
 import { AlertTriangle } from "lucide-react"
 import type { ReactElement, ReactNode } from "react"
 import { Alert, AlertDescription, AlertTitle } from "../../components/alert.tsx"
-import { useBackendApiClient } from "../../lib/api/BackendApiClientContext.tsx"
+import { useCurrentActionQuery } from "../../lib/api/useCurrentActionQuery.ts"
 import { useLogger } from "../../lib/LoggerContext.tsx"
 import { GameActionSelector, GameActionSelectorSkeleton } from "./components/GameActionSelector.tsx"
 import { usePlayGameContext } from "./PlayContext.tsx"
@@ -15,8 +14,7 @@ function PlayerActionsContainer({ children }: { children: ReactNode }): ReactEle
 export function PlayerActionsPage({ gameId }: { gameId: GameId }): ReactElement {
   const logger = useLogger()
   const { playerView } = usePlayGameContext()
-  const backendApiClient = useBackendApiClient()
-  const currentActionQuery = useQuery(backendApiClient.gameplay.getCurrentAction.queryOptions({ gameId }))
+  const currentActionQuery = useCurrentActionQuery(gameId)
 
   if (currentActionQuery.isPending) {
     return (

--- a/frontend/src/features/play/components/GameActionSelector.tsx
+++ b/frontend/src/features/play/components/GameActionSelector.tsx
@@ -1,12 +1,11 @@
 import type * as ApiTypes from "@api-types"
 import type { PlayerView } from "@api-types"
-import { useMutation } from "@tanstack/react-query"
 import { AlertTriangle, CheckCircle2, Coins } from "lucide-react"
 import type { KeyboardEvent, ReactElement } from "react"
 import { Alert, AlertDescription, AlertTitle } from "../../../components/alert.tsx"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../../components/card.tsx"
 import { Skeleton } from "../../../components/skeleton.tsx"
-import { useBackendApiClient } from "../../../lib/api/BackendApiClientContext.tsx"
+import { useSetCurrentActionMutation } from "../../../lib/api/useSetCurrentActionMutation.ts"
 import { cn } from "../../../lib/cn.ts"
 
 const PLAYER_ACTIONS = [
@@ -41,8 +40,7 @@ export function GameActionSelector({
   playerView: PlayerView
   currentAction: ApiTypes.GamePlayerAction | null
 }): ReactElement {
-  const backendApiClient = useBackendApiClient()
-  const setCurrentAction = useMutation(backendApiClient.gameplay.setCurrentAction.mutationOptions())
+  const setCurrentAction = useSetCurrentActionMutation()
 
   return (
     <section className="flex flex-col gap-5">

--- a/frontend/src/lib/api/useCreateGameMutation.ts
+++ b/frontend/src/lib/api/useCreateGameMutation.ts
@@ -1,0 +1,16 @@
+import { useMutation } from "@tanstack/react-query"
+import { useNavigate } from "@tanstack/react-router"
+import { useBackendApiClient } from "./BackendApiClientContext.tsx"
+
+// oxlint-disable-next-line typescript/explicit-function-return-type -- Let tRPC and TanStack Query inference do the work
+export function useCreateGameMutation() {
+  const backendApiClient = useBackendApiClient()
+  const navigate = useNavigate()
+
+  return useMutation({
+    ...backendApiClient.lobbies.create.mutationOptions(),
+    onSuccess: async ({ createdGameId }) => {
+      await navigate({ to: "/games/$gameId", params: { gameId: createdGameId } })
+    },
+  })
+}

--- a/frontend/src/lib/api/useCurrentActionQuery.ts
+++ b/frontend/src/lib/api/useCurrentActionQuery.ts
@@ -1,0 +1,10 @@
+import type { GameId } from "@api-types"
+import { useQuery } from "@tanstack/react-query"
+import { useBackendApiClient } from "./BackendApiClientContext.tsx"
+
+// oxlint-disable-next-line typescript/explicit-function-return-type -- Let tRPC and TanStack Query inference do the work
+export function useCurrentActionQuery(gameId: GameId) {
+  const backendApiClient = useBackendApiClient()
+
+  return useQuery(backendApiClient.gameplay.getCurrentAction.queryOptions({ gameId }))
+}

--- a/frontend/src/lib/api/useJoinGameMutation.ts
+++ b/frontend/src/lib/api/useJoinGameMutation.ts
@@ -1,0 +1,9 @@
+import { useMutation } from "@tanstack/react-query"
+import { useBackendApiClient } from "./BackendApiClientContext.tsx"
+
+// oxlint-disable-next-line typescript/explicit-function-return-type -- Let tRPC and TanStack Query inference do the work
+export function useJoinGameMutation() {
+  const backendApiClient = useBackendApiClient()
+
+  return useMutation(backendApiClient.lobbies.join.mutationOptions())
+}

--- a/frontend/src/lib/api/useLeaveGameMutation.ts
+++ b/frontend/src/lib/api/useLeaveGameMutation.ts
@@ -1,0 +1,9 @@
+import { useMutation } from "@tanstack/react-query"
+import { useBackendApiClient } from "./BackendApiClientContext.tsx"
+
+// oxlint-disable-next-line typescript/explicit-function-return-type -- Let tRPC and TanStack Query inference do the work
+export function useLeaveGameMutation() {
+  const backendApiClient = useBackendApiClient()
+
+  return useMutation(backendApiClient.lobbies.leave.mutationOptions())
+}

--- a/frontend/src/lib/api/useListingsQuery.ts
+++ b/frontend/src/lib/api/useListingsQuery.ts
@@ -1,0 +1,9 @@
+import { useQuery } from "@tanstack/react-query"
+import { useBackendApiClient } from "./BackendApiClientContext.tsx"
+
+// oxlint-disable-next-line typescript/explicit-function-return-type -- Let tRPC and TanStack Query inference do the work
+export function useListingsQuery() {
+  const backendApiClient = useBackendApiClient()
+
+  return useQuery(backendApiClient.listings.getListings.queryOptions())
+}

--- a/frontend/src/lib/api/useLobbyCreationSettingsQuery.ts
+++ b/frontend/src/lib/api/useLobbyCreationSettingsQuery.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query"
+import { useBackendApiClient } from "./BackendApiClientContext.tsx"
+
+// oxlint-disable-next-line typescript/explicit-function-return-type -- Let tRPC and TanStack Query inference do the work
+export function useLobbyCreationSettingsQuery() {
+  const backendApiClient = useBackendApiClient()
+
+  return useQuery({
+    ...backendApiClient.lobbies.getCreationSettings.queryOptions(),
+    staleTime: Infinity,
+    gcTime: Infinity,
+    refetchOnMount: "always",
+  })
+}

--- a/frontend/src/lib/api/useLobbyQuery.ts
+++ b/frontend/src/lib/api/useLobbyQuery.ts
@@ -1,0 +1,10 @@
+import type { GameId } from "@api-types"
+import { useQuery } from "@tanstack/react-query"
+import { useBackendApiClient } from "./BackendApiClientContext.tsx"
+
+// oxlint-disable-next-line typescript/explicit-function-return-type -- Let tRPC and TanStack Query inference do the work
+export function useLobbyQuery(gameId: GameId) {
+  const backendApiClient = useBackendApiClient()
+
+  return useQuery(backendApiClient.lobbies.getById.queryOptions({ gameId }))
+}

--- a/frontend/src/lib/api/usePlayerViewQuery.ts
+++ b/frontend/src/lib/api/usePlayerViewQuery.ts
@@ -1,0 +1,10 @@
+import type { GameId } from "@api-types"
+import { useQuery } from "@tanstack/react-query"
+import { useBackendApiClient } from "./BackendApiClientContext.tsx"
+
+// oxlint-disable-next-line typescript/explicit-function-return-type -- Let tRPC and TanStack Query inference do the work
+export function usePlayerViewQuery(gameId: GameId) {
+  const backendApiClient = useBackendApiClient()
+
+  return useQuery(backendApiClient.gameplay.getPlayerView.queryOptions({ gameId }))
+}

--- a/frontend/src/lib/api/useSetCurrentActionMutation.ts
+++ b/frontend/src/lib/api/useSetCurrentActionMutation.ts
@@ -1,0 +1,9 @@
+import { useMutation } from "@tanstack/react-query"
+import { useBackendApiClient } from "./BackendApiClientContext.tsx"
+
+// oxlint-disable-next-line typescript/explicit-function-return-type -- Let tRPC and TanStack Query inference do the work
+export function useSetCurrentActionMutation() {
+  const backendApiClient = useBackendApiClient()
+
+  return useMutation(backendApiClient.gameplay.setCurrentAction.mutationOptions())
+}

--- a/frontend/src/lib/api/useStartGameMutation.ts
+++ b/frontend/src/lib/api/useStartGameMutation.ts
@@ -1,0 +1,9 @@
+import { useMutation } from "@tanstack/react-query"
+import { useBackendApiClient } from "./BackendApiClientContext.tsx"
+
+// oxlint-disable-next-line typescript/explicit-function-return-type -- Let tRPC and TanStack Query inference do the work
+export function useStartGameMutation() {
+  const backendApiClient = useBackendApiClient()
+
+  return useMutation(backendApiClient.gameplay.startGame.mutationOptions())
+}


### PR DESCRIPTION
## Issue

- fixes #258

## Summary

- add dedicated query and mutation hooks for the frontend's lobby, listings, and gameplay operations
- centralize operation-specific behavior, including creation-settings cache policy and post-creation navigation
- migrate feature pages and components away from composing `useBackendApiClient` with React Query directly

This reduces page-level API boilerplate and provides reusable entry points for each backend operation without changing backend contracts or user-facing behavior.

## Validation

- `pnpm --filter frontend checks`
- `pnpm lint`
- focused `oxfmt --check` on all changed files