### PR TITLE
backend: wrap createTransaction in a Result.tryCatch to always return results

### DIFF
--- a/backend/scripts/db/seed.ts
+++ b/backend/scripts/db/seed.ts
@@ -8,7 +8,7 @@ import { createStarSystemGenerationSettingsDefaults } from "#api/gameplay/star-s
 import { LobbiesController } from "#api/lobbies/lobbies.controller.ts"
 import { LobbiesRepository } from "#api/lobbies/lobbies.repository.ts"
 import { configureLogger } from "#lib/configureLogger.ts"
-import { createDb, type Database } from "#lib/db/createDb.ts"
+import { createCreateTransaction, createDb, type Database } from "#lib/db/createDb.ts"
 import { accountsTable, gamesTable } from "#lib/db/schema.ts"
 import { parseEnv } from "#lib/parseEnv.ts"
 
@@ -76,7 +76,7 @@ async function main({ connectionString, user }: { connectionString: string; user
   const accountsRepository = new AccountsRepository({ db, logger })
   const lobbiesController = new LobbiesController({
     logger,
-    createTransaction: db.transaction.bind(db),
+    createTransaction: createCreateTransaction(db),
     lobbiesRepository: new LobbiesRepository({ db, logger }),
   })
 

--- a/backend/src/api/createApi.stub.ts
+++ b/backend/src/api/createApi.stub.ts
@@ -8,7 +8,7 @@ import { ListingsRepository } from "#api/listings/listings.repository.ts"
 import { LobbiesRepository } from "#api/lobbies/lobbies.repository.ts"
 import { Clock } from "#lib/Clock.ts"
 import { createDbMock } from "#lib/db/createDb.mock.ts"
-import type { Database } from "#lib/db/createDb.ts"
+import { createCreateTransaction, type Database } from "#lib/db/createDb.ts"
 
 type AllServices = Omit<Parameters<typeof createApi>[0], "authService"> & { authService: AuthServiceMock }
 
@@ -25,7 +25,7 @@ export async function createApiStub({ db, clock = Clock }: { db?: Database; cloc
     logger,
     clock,
     authService: new AuthServiceMock(),
-    createTransaction: db.transaction.bind(db),
+    createTransaction: createCreateTransaction(db),
     accountsRepository: new AccountsRepository({ db, logger }),
     listingsRepository: new ListingsRepository({ db, logger }),
     lobbiesRepository: new LobbiesRepository({ db, logger }),

--- a/backend/src/api/entry.api.ts
+++ b/backend/src/api/entry.api.ts
@@ -8,8 +8,7 @@ import { ListingsRepository } from "#api/listings/listings.repository.ts"
 import { LobbiesRepository } from "#api/lobbies/lobbies.repository.ts"
 import { Clock } from "#lib/Clock.ts"
 import { configureLogger } from "#lib/configureLogger.ts"
-import type { Database } from "#lib/db/createDb.ts"
-import { createDb } from "#lib/db/createDb.ts"
+import { createDb, createCreateTransaction, type Database } from "#lib/db/createDb.ts"
 import { envSchema, parseEnv } from "#lib/parseEnv.ts"
 import { startTickProcessing } from "#tick-processing/entry.tick-processing.ts"
 import { createApi } from "./createApi.ts"
@@ -50,7 +49,7 @@ async function main(): Promise<void> {
   const app = await createApi({
     logger,
     clock,
-    createTransaction: db.transaction.bind(db),
+    createTransaction: createCreateTransaction(db),
     authService,
     ...repositories,
   })

--- a/backend/src/api/lobbies/lobbies.controller.ts
+++ b/backend/src/api/lobbies/lobbies.controller.ts
@@ -66,26 +66,24 @@ export class LobbiesController {
   }
 
   public async joinLobby({ gameId, accountId }: JoinLobbyDto): Promise<Result<JoinedLobbyDto, string>> {
-    const joinGameResult = await Result.tryCatch(
-      this.createTransaction(async (tx) => {
-        const lobbyModelResult = await this.lobbiesRepository.getLobbyById({ gameId }, tx)
-        rollbackOnFailure(lobbyModelResult, "Failed to get game lobby")
+    const joinGameResult = await this.createTransaction(async (tx) => {
+      const lobbyModelResult = await this.lobbiesRepository.getLobbyById({ gameId }, tx)
+      rollbackOnFailure(lobbyModelResult, "Failed to get game lobby")
 
-        const lobbyModel = lobbyModelResult.value
-        if (lobbyModel === undefined) {
-          throw new TransactionRollback("Cannot join game lobby, it could not be found")
-        }
+      const lobbyModel = lobbyModelResult.value
+      if (lobbyModel === undefined) {
+        throw new TransactionRollback("Cannot join game lobby, it could not be found")
+      }
 
-        if (!toLobbyDto({ lobbyModel, playerId: accountId }).canJoin) {
-          throw new TransactionRollback("Cannot join game lobby, this player is not allowed to join it at the moment")
-        }
+      if (!toLobbyDto({ lobbyModel, playerId: accountId }).canJoin) {
+        throw new TransactionRollback("Cannot join game lobby, this player is not allowed to join it at the moment")
+      }
 
-        const joinResult = await this.lobbiesRepository.joinLobby({ gameId, accountId }, tx)
-        rollbackOnFailure(joinResult, "Failed to join game")
+      const joinResult = await this.lobbiesRepository.joinLobby({ gameId, accountId }, tx)
+      rollbackOnFailure(joinResult, "Failed to join game")
 
-        return joinResult.value
-      }),
-    )
+      return joinResult.value
+    })
 
     if (Result.isFailure(joinGameResult)) {
       this.logger.error("Could not join game lobby", { gameId, playerId: accountId, error: joinGameResult.error })
@@ -96,24 +94,22 @@ export class LobbiesController {
   }
 
   public async leaveLobby({ gameId, accountId }: LeaveLobbyDto): Promise<Result<LeftLobbyDto, string>> {
-    const leaveGameResult = await Result.tryCatch(
-      this.createTransaction(async (tx): Promise<void> => {
-        const lobbyResult = await this.lobbiesRepository.getLobbyById({ gameId }, tx)
-        rollbackOnFailure(lobbyResult, "Failed to get game lobby")
+    const leaveGameResult = await this.createTransaction(async (tx) => {
+      const lobbyResult = await this.lobbiesRepository.getLobbyById({ gameId }, tx)
+      rollbackOnFailure(lobbyResult, "Failed to get game lobby")
 
-        const lobbyModel = lobbyResult.value
-        if (lobbyModel === undefined) {
-          throw new TransactionRollback("Cannot leave game lobby, it could not be found")
-        }
+      const lobbyModel = lobbyResult.value
+      if (lobbyModel === undefined) {
+        throw new TransactionRollback("Cannot leave game lobby, it could not be found")
+      }
 
-        if (!toLobbyDto({ lobbyModel, playerId: accountId }).canLeave) {
-          throw new TransactionRollback("Cannot leave game lobby, this player is not allowed to leave it at the moment")
-        }
+      if (!toLobbyDto({ lobbyModel, playerId: accountId }).canLeave) {
+        throw new TransactionRollback("Cannot leave game lobby, this player is not allowed to leave it at the moment")
+      }
 
-        const leaveResult = await this.lobbiesRepository.leaveLobby({ gameId, accountId }, tx)
-        rollbackOnFailure(leaveResult, "Failed to leave game lobby")
-      }),
-    )
+      const leaveResult = await this.lobbiesRepository.leaveLobby({ gameId, accountId }, tx)
+      rollbackOnFailure(leaveResult, "Failed to leave game lobby")
+    })
 
     if (Result.isFailure(leaveGameResult)) {
       this.logger.error("Could not leave game lobby", { gameId, accountId, error: leaveGameResult.error })

--- a/backend/src/lib/db/createDb.ts
+++ b/backend/src/lib/db/createDb.ts
@@ -1,8 +1,13 @@
+import { Result } from "@guillaume-docquier/tools-ts"
 import { drizzle } from "drizzle-orm/node-postgres"
 
 export type Database = ReturnType<typeof createDb>
-export type CreateTransaction = Database["transaction"]
-export type Transaction = Parameters<Parameters<CreateTransaction>[0]>[0]
+export type Transaction = Parameters<Parameters<Database["transaction"]>[0]>[0]
+
+export type CreateTransaction = <T>(operation: (tx: Transaction) => Promise<T>) => Promise<Result<T, Error>>
+export function createCreateTransaction(db: Database): CreateTransaction {
+  return async (operation) => await Result.tryCatch(db.transaction(operation))
+}
 
 /**
  * Connects to the database.


### PR DESCRIPTION
## Issue

`createTransaction` was always used with `Result.tryCatch` by design, so we integrated `Result.tryCatch` in `createTransaction`
