### PR TITLE
backend: use engines to tell Railway which pnpm version to use

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,1 @@
-sh .husky/sync-mise.sh
 pnpm lint-staged

--- a/.husky/sync-mise.sh
+++ b/.husky/sync-mise.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Keeps the pnpm version in mise.toml synced with packageJson.devEngines.packageManager.version
-version=$(jq -r '.devEngines.packageManager.version' package.json)
-sed -i "s/^pnpm = .*/pnpm = \"$version\"/" mise.toml
-
-git add mise.toml

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,0 @@
-# I don't know yet if it's a bug or a misuse, but devEngines.packageManager on Railway causes 3x-4x memory usage compared to packageManager.
-# They seem to support the engines and packageManager fields correctly, but not devEngines.
-# We chose mise.toml to tell Railway which pnpm version to use because it won't interact with other tools we use (we don't use mise, but Railway does) and we can leave comments.
-# We have a husky precommit hook keep this file synced so we don't have to worry about it.
-
-[tools]
-pnpm = "11.9.0"

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
       "version": "24.16.0",
       "onFail": "download"
     }
+  },
+  "engines": {
+    "pnpm": "11.9.0"
   }
 }


### PR DESCRIPTION
## Issue

- part of https://github.com/Guillaume-Docquier/text-based-browser-game-1/issues/280

## Description

In https://github.com/Guillaume-Docquier/text-based-browser-game-1/pull/286 we tried to use mise.toml, to no avail.

Let's try the engines field, [they say they support it](https://railpack.com/languages/node/#package-managers)