### PR TITLE
backend: improve tick-processing logging and add memory usage logs

### DIFF
--- a/backend/src/api/entry.api.ts
+++ b/backend/src/api/entry.api.ts
@@ -1,4 +1,4 @@
-import { Logger } from "@guillaume-docquier/tools-ts"
+import { Logger, Profile, Time, UnitOfTime } from "@guillaume-docquier/tools-ts"
 import { migrate } from "drizzle-orm/node-postgres/migrator"
 import pRetry from "p-retry"
 import { AccountsRepository } from "#api/accounts/accounts.repository.ts"
@@ -8,8 +8,9 @@ import { ListingsRepository } from "#api/listings/listings.repository.ts"
 import { LobbiesRepository } from "#api/lobbies/lobbies.repository.ts"
 import { Clock } from "#lib/Clock.ts"
 import { configureLogger } from "#lib/configureLogger.ts"
-import { createDb, createCreateTransaction, type Database } from "#lib/db/createDb.ts"
+import { createCreateTransaction, createDb, type Database } from "#lib/db/createDb.ts"
 import { envSchema, parseEnv } from "#lib/parseEnv.ts"
+import { repeat } from "#lib/repeat.ts"
 import { startTickProcessing } from "#tick-processing/entry.tick-processing.ts"
 import { createApi } from "./createApi.ts"
 
@@ -61,6 +62,16 @@ async function main(): Promise<void> {
 
   logger.info("Starting tick processing")
   startTickProcessing({ logger })
+
+  // We'll capture the memory usage reported by node a few times to compare with what Railway says
+  // There's always a spike at launch, which should settle after a minute or two
+  repeat({
+    times: 5,
+    delay: Time.create(1, UnitOfTime.MINUTES),
+    operation: () => {
+      Profile.memoryUsage(logger)
+    },
+  })
 }
 
 /**

--- a/backend/src/lib/repeat.ts
+++ b/backend/src/lib/repeat.ts
@@ -1,0 +1,18 @@
+import { Assert, Time, UnitOfTime } from "@guillaume-docquier/tools-ts"
+
+export function repeat({ times, delay, operation }: { times: number; delay: Time; operation: () => void }): void {
+  Assert.isTrue(times > 0)
+
+  let nbExecutions = 1
+  operation()
+  const interval = setInterval(
+    () => {
+      operation()
+      nbExecutions++
+      if (nbExecutions >= times) {
+        clearInterval(interval)
+      }
+    },
+    Time.in(delay, UnitOfTime.MILLISECONDS),
+  )
+}

--- a/backend/src/tick-processing/ElapsedTimeContextProvider.ts
+++ b/backend/src/tick-processing/ElapsedTimeContextProvider.ts
@@ -1,0 +1,12 @@
+import { type LogContext, type LogContextProvider, Timer } from "@guillaume-docquier/tools-ts"
+
+/**
+ * Captures the start time on creation and adds the elapsed time to every log
+ */
+export class ElapsedTimeContextProvider implements LogContextProvider {
+  private readonly startTime = Timer.start()
+
+  public getContext(): LogContext {
+    return { elapsedTime: Timer.since(this.startTime) }
+  }
+}

--- a/backend/src/tick-processing/TickProcessor.ts
+++ b/backend/src/tick-processing/TickProcessor.ts
@@ -1,4 +1,4 @@
-import { Assert, Datetime, type Logger, Profile, Result, Time, UnitOfTime } from "@guillaume-docquier/tools-ts"
+import { Assert, Datetime, type Logger, Result, Time, UnitOfTime } from "@guillaume-docquier/tools-ts"
 import type { Clock } from "#lib/Clock.ts"
 import type { AccountId } from "#lib/db/accounts/AccountId.ts"
 import type { CreateTransaction } from "#lib/db/createDb.ts"
@@ -6,6 +6,7 @@ import { GAME_PLAYER_ACTION_RULES } from "#lib/db/gameplay/gamePlayerActions.ts"
 import { GamePlayerActionType } from "#lib/db/gameplay/gamePlayerActionType.ts"
 import { ResourceType } from "#lib/db/gameplay/gameResources.ts"
 import { rollbackOnFailure } from "#lib/errors.ts"
+import { ElapsedTimeContextProvider } from "#tick-processing/ElapsedTimeContextProvider.ts"
 import { type ProcessedTickModel, type TicksRepository, type TickToProcessModel } from "#tick-processing/ticks.repository.ts"
 
 export class TickProcessor {
@@ -36,47 +37,45 @@ export class TickProcessor {
    * This will resolve all player actions, update the game state and schedule the next tick.
    */
   public async processNextDueTick(): Promise<void> {
-    await Profile.executionTime(
-      "processNextDueTick",
-      async () => {
-        const tickToProcessResult = await this.createTransaction(async (tx) => {
-          const nextTickToProcessResult = await this.ticksRepository.getNextTickToProcess({ since: this.clock.now() }, tx)
-          rollbackOnFailure(nextTickToProcessResult, "Could not get next tick to process")
+    const processingLogger = this.logger.child({ scope: "processNextDueTick", contextProviders: [new ElapsedTimeContextProvider()] })
 
-          if (nextTickToProcessResult.value === undefined) {
-            return undefined
-          }
+    const tickToProcessResult = await this.createTransaction(async (tx) => {
+      const nextTickToProcessResult = await this.ticksRepository.getNextTickToProcess({ since: this.clock.now() }, tx)
+      rollbackOnFailure(nextTickToProcessResult, "Could not get next tick to process")
 
-          const started = await this.ticksRepository.startProcessingTick(nextTickToProcessResult.value, tx)
-          rollbackOnFailure(started, "Could not start to process next tick")
+      if (nextTickToProcessResult.value === undefined) {
+        return undefined
+      }
 
-          return nextTickToProcessResult.value
-        })
+      const started = await this.ticksRepository.startProcessingTick(nextTickToProcessResult.value, tx)
+      rollbackOnFailure(started, "Could not start to process next tick")
 
-        if (Result.isFailure(tickToProcessResult)) {
-          this.logger.error("Failed to acquire next tick to process", { error: tickToProcessResult.error })
-          return
-        }
+      return nextTickToProcessResult.value
+    })
 
-        const tickToProcess = tickToProcessResult.value
-        if (tickToProcess === undefined) {
-          this.logger.debug("No tick to process")
-          return
-        }
+    if (Result.isFailure(tickToProcessResult)) {
+      processingLogger.error("Failed to acquire next tick to process", { error: tickToProcessResult.error })
+      return
+    }
 
-        this.logger.info("Processing tick", { gameId: tickToProcess.gameId, tick: tickToProcess.tick })
-        const processedTick = this.processTick(tickToProcess)
-        const saveResult = await this.ticksRepository.saveProcessedTick(processedTick)
-        if (Result.isFailure(saveResult)) {
-          this.logger.error("Could not save processed tick", {
-            gameId: tickToProcess.gameId,
-            tick: tickToProcess.tick,
-            error: saveResult.error,
-          })
-        }
-      },
-      this.logger,
-    )
+    const tickToProcess = tickToProcessResult.value
+    if (tickToProcess === undefined) {
+      processingLogger.debug("No tick to process")
+      return
+    }
+
+    processingLogger.info("Processing tick", { gameId: tickToProcess.gameId, tick: tickToProcess.tick })
+    const processedTick = this.processTick(tickToProcess)
+    const saveResult = await this.ticksRepository.saveProcessedTick(processedTick)
+    if (Result.isFailure(saveResult)) {
+      processingLogger.error("Could not save processed tick", {
+        gameId: tickToProcess.gameId,
+        tick: tickToProcess.tick,
+        error: saveResult.error,
+      })
+    } else {
+      processingLogger.info("Tick processed", { gameId: tickToProcess.gameId, tick: tickToProcess.tick })
+    }
   }
 
   private processTick(tickToProcess: TickToProcessModel): ProcessedTickModel {

--- a/backend/src/tick-processing/entry.tick-processing.ts
+++ b/backend/src/tick-processing/entry.tick-processing.ts
@@ -1,9 +1,10 @@
 import { SHARE_ENV, Worker, isMainThread } from "node:worker_threads"
-import { type Logger } from "@guillaume-docquier/tools-ts"
+import { type Logger, Profile, Time, UnitOfTime } from "@guillaume-docquier/tools-ts"
 import { Clock } from "#lib/Clock.ts"
 import { configureLogger } from "#lib/configureLogger.ts"
 import { createCreateTransaction, createDb } from "#lib/db/createDb.ts"
 import { envSchema, parseEnv } from "#lib/parseEnv.ts"
+import { repeat } from "#lib/repeat.ts"
 import { TickProcessor } from "#tick-processing/TickProcessor.ts"
 import { TicksRepository } from "#tick-processing/ticks.repository.ts"
 
@@ -49,6 +50,16 @@ if (!isMainThread) {
 
   logger.info("Processing ticks forever")
   await processTicksForever(tickProcessor, 1000)
+
+  // We'll capture the memory usage reported by node a few times to compare with what Railway says
+  // There's always a spike at launch, which should settle after a minute or two
+  repeat({
+    times: 5,
+    delay: Time.create(1, UnitOfTime.MINUTES),
+    operation: () => {
+      Profile.memoryUsage(logger)
+    },
+  })
 }
 
 async function processTicksForever(tickProcessor: TickProcessor, frequency: number): Promise<void> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@guillaume-docquier/tools-ts':
-      specifier: ^6.1.0
-      version: 6.1.0
+      specifier: ^6.2.0
+      version: 6.2.0
     '@typescript/native-preview':
       specifier: 7.0.0-dev.20260622.1
       version: 7.0.0-dev.20260622.1
@@ -43,7 +43,7 @@ importers:
         version: 2.1.31(express@5.2.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@guillaume-docquier/tools-ts':
         specifier: 'catalog:'
-        version: 6.1.0
+        version: 6.2.0
       '@trpc/server':
         specifier: ^11.18.0
         version: 11.18.0(typescript@7.0.1-rc)
@@ -110,7 +110,7 @@ importers:
         version: 5.2.8
       '@guillaume-docquier/tools-ts':
         specifier: 'catalog:'
-        version: 6.1.0
+        version: 6.2.0
       '@tanstack/react-query':
         specifier: ^5.101.1
         version: 5.101.1(react@19.2.7)
@@ -963,8 +963,8 @@ packages:
   '@formkit/auto-animate@0.8.4':
     resolution: {integrity: sha512-DHHC01EJ1p70Q0z/ZFRBIY8NDnmfKccQoyoM84Tgb6omLMat6jivCdf272Y8k3nf4Lzdin/Y4R9q8uFtU0GbnA==}
 
-  '@guillaume-docquier/tools-ts@6.1.0':
-    resolution: {integrity: sha512-IJPjmcdVjvv52gauVc5ovm7LzD4iNDfW+7vv6QjgogHpX7eA1xcf8VvAoVed3skXXtf5pFQ1N1rrx16lo2aUdg==}
+  '@guillaume-docquier/tools-ts@6.2.0':
+    resolution: {integrity: sha512-znUhW8J/bRa8c3fxhg6t8LSQesq/dBR4A6x0jkCXwQWFmcz0C+N9gr+3qBWO5GWrWEWbPxjfKSjo6Z0CmqOyLA==}
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -7401,7 +7401,7 @@ snapshots:
 
   '@formkit/auto-animate@0.8.4': {}
 
-  '@guillaume-docquier/tools-ts@6.1.0':
+  '@guillaume-docquier/tools-ts@6.2.0':
     dependencies:
       '@logtape/logtape': 2.2.1
       '@logtape/redaction': 2.2.1(@logtape/logtape@2.2.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ packages:
   - frontend
 
 catalog:
-  "@guillaume-docquier/tools-ts": ^6.1.0
+  "@guillaume-docquier/tools-ts": ^6.2.0
   "@typescript/native-preview": 7.0.0-dev.20260622.1
 
 minimumReleaseAgeExclude:


### PR DESCRIPTION
## Issue

- fixes https://github.com/Guillaume-Docquier/text-based-browser-game-1/issues/281

## Description

The current tick processing performance logs were on info instead of debug, and didn't use structured logging

We had issues with Railway reporting high memory usage and I'm curious why. Locally, we start at ~200MB and go down to ~100MB within a minute.
