### PR TITLE
backend: drain due ticks before waiting

### DIFF
--- a/backend/src/api/entry.api.ts
+++ b/backend/src/api/entry.api.ts
@@ -1,4 +1,4 @@
-import { Logger, Profile, Time, UnitOfTime } from "@guillaume-docquier/tools-ts"
+import { Logger } from "@guillaume-docquier/tools-ts"
 import { migrate } from "drizzle-orm/node-postgres/migrator"
 import pRetry from "p-retry"
 import { AccountsRepository } from "#api/accounts/accounts.repository.ts"
@@ -9,8 +9,8 @@ import { LobbiesRepository } from "#api/lobbies/lobbies.repository.ts"
 import { Clock } from "#lib/Clock.ts"
 import { configureLogger } from "#lib/configureLogger.ts"
 import { createCreateTransaction, createDb, type Database } from "#lib/db/createDb.ts"
+import { monitorMemoryUsage } from "#lib/monitorMemoryUsage.ts"
 import { envSchema, parseEnv } from "#lib/parseEnv.ts"
-import { repeat } from "#lib/repeat.ts"
 import { startTickProcessing } from "#tick-processing/entry.tick-processing.ts"
 import { createApi } from "./createApi.ts"
 
@@ -63,15 +63,7 @@ async function main(): Promise<void> {
   logger.info("Starting tick processing")
   startTickProcessing({ logger })
 
-  // We'll capture the memory usage reported by node a few times to compare with what Railway says
-  // There's always a spike at launch, which should settle after a minute or two
-  repeat({
-    times: 5,
-    delay: Time.create(1, UnitOfTime.MINUTES),
-    operation: () => {
-      Profile.memoryUsage(logger)
-    },
-  })
+  monitorMemoryUsage({ logger })
 }
 
 /**

--- a/backend/src/lib/monitorMemoryUsage.ts
+++ b/backend/src/lib/monitorMemoryUsage.ts
@@ -1,0 +1,14 @@
+import { type Logger, Profile, Time, UnitOfTime } from "@guillaume-docquier/tools-ts"
+import { repeat } from "#lib/repeat.ts"
+
+export function monitorMemoryUsage({ logger }: { logger: Logger }): void {
+  // We'll capture the memory usage reported by node a few times to compare with what Railway says
+  // There's always a spike at launch, which should settle after a minute or two
+  repeat({
+    times: 5,
+    delay: Time.create(1, UnitOfTime.MINUTES),
+    operation: () => {
+      Profile.memoryUsage(logger)
+    },
+  })
+}

--- a/backend/src/tick-processing/TickProcessor.test.ts
+++ b/backend/src/tick-processing/TickProcessor.test.ts
@@ -1,6 +1,6 @@
 import { Assert, Datetime, Result, Time, UnitOfTime } from "@guillaume-docquier/tools-ts"
 import { v4 } from "uuid"
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { createNewAccountModelStub } from "#api/accounts/NewAccountModel.stub.ts"
 import { createApiStub } from "#api/createApi.stub.ts"
 import { createGameConfigurationDtoStub } from "#api/lobbies/GameConfigurationDto.stub.ts"
@@ -14,7 +14,12 @@ import { TrpcClient } from "#tests/TrpcClient.ts"
 import { createTickProcessorStub } from "#tick-processing/TickProcessor.stub.ts"
 import { type ProcessedTickModel, TicksRepository } from "#tick-processing/ticks.repository.ts"
 
-describe("processTick", () => {
+describe("TickProcessor", () => {
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
   it("should process the current tick and queue the next one", async () => {
     // Arrange
     const db = await createDbMock()
@@ -156,6 +161,93 @@ describe("processTick", () => {
     expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: earlierGameId })).toMatchObject({
       tick: 1,
       resources: { money: 1 },
+    })
+  })
+
+  it("should process all currently due ticks before waiting", async () => {
+    // Arrange
+    const db = await createDbMock()
+    const clock = new ControlledClock({ startDate: new Date(0) })
+    const { api, authService, accountsRepository } = await createApiStub({ db, clock })
+    using trpcClient = new TrpcClient({ api })
+
+    authService.account = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
+
+    const tickInterval = Time.create(100, UnitOfTime.SECONDS)
+    const { createdGameId: firstGameId } = await trpcClient.client.lobbies.create.mutate({
+      configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(tickInterval, UnitOfTime.SECONDS) }),
+    })
+    await trpcClient.client.gameplay.startGame.mutate({ gameId: firstGameId })
+
+    const { createdGameId: secondGameId } = await trpcClient.client.lobbies.create.mutate({
+      configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(tickInterval, UnitOfTime.SECONDS) }),
+    })
+    await trpcClient.client.gameplay.startGame.mutate({ gameId: secondGameId })
+
+    const { tickProcessor } = await createTickProcessorStub({ db, clock })
+
+    // Act
+    vi.useFakeTimers()
+    clock.increment({ time: tickInterval })
+    await tickProcessor.processTicksForever(1000)
+
+    // Assert
+    expect(vi.getTimerCount()).toBe(1)
+    vi.clearAllTimers()
+    vi.useRealTimers()
+
+    expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: firstGameId })).toMatchObject({
+      tick: 1,
+      resources: { money: 1 },
+    })
+
+    expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: secondGameId })).toMatchObject({
+      tick: 1,
+      resources: { money: 1 },
+    })
+  })
+
+  it("should wait before retrying when the selected tick processing fails", async () => {
+    // Arrange
+    const db = await createDbMock()
+    const clock = new ControlledClock({ startDate: new Date(0) })
+    const { api, authService, accountsRepository, logger } = await createApiStub({ db, clock })
+    using trpcClient = new TrpcClient({ api })
+
+    authService.account = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
+
+    const tickInterval = Time.create(100, UnitOfTime.SECONDS)
+    const { createdGameId: failingGameId } = await trpcClient.client.lobbies.create.mutate({
+      configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(tickInterval, UnitOfTime.SECONDS) }),
+    })
+    await trpcClient.client.gameplay.startGame.mutate({ gameId: failingGameId })
+
+    const { createdGameId: successfulGameId } = await trpcClient.client.lobbies.create.mutate({
+      configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(tickInterval, UnitOfTime.SECONDS) }),
+    })
+    await trpcClient.client.gameplay.startGame.mutate({ gameId: successfulGameId })
+
+    const ticksRepository = new FailingTicksRepository({ db, logger, clock, failingGameId })
+    const { tickProcessor } = await createTickProcessorStub({ db, clock, ticksRepository })
+
+    // Act
+    vi.useFakeTimers()
+    clock.increment({ time: tickInterval })
+    await tickProcessor.processTicksForever(1000)
+
+    // Assert
+    expect(vi.getTimerCount()).toBe(1)
+    vi.clearAllTimers()
+    vi.useRealTimers()
+
+    expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: failingGameId })).toMatchObject({
+      tick: 0,
+      resources: { money: 0 },
+    })
+
+    expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: successfulGameId })).toMatchObject({
+      tick: 0,
+      resources: { money: 0 },
     })
   })
 

--- a/backend/src/tick-processing/TickProcessor.test.ts
+++ b/backend/src/tick-processing/TickProcessor.test.ts
@@ -189,7 +189,7 @@ describe("TickProcessor", () => {
     // Act
     vi.useFakeTimers()
     clock.increment({ time: tickInterval })
-    await tickProcessor.processTicksForever(1000)
+    await tickProcessor.processTicksForever({ interval: Time.create(1, UnitOfTime.SECONDS) })
 
     // Assert
     expect(vi.getTimerCount()).toBe(1)
@@ -233,7 +233,7 @@ describe("TickProcessor", () => {
     // Act
     vi.useFakeTimers()
     clock.increment({ time: tickInterval })
-    await tickProcessor.processTicksForever(1000)
+    await tickProcessor.processTicksForever({ interval: Time.create(1, UnitOfTime.SECONDS) })
 
     // Assert
     expect(vi.getTimerCount()).toBe(1)

--- a/backend/src/tick-processing/TickProcessor.test.ts
+++ b/backend/src/tick-processing/TickProcessor.test.ts
@@ -15,526 +15,533 @@ import { createTickProcessorStub } from "#tick-processing/TickProcessor.stub.ts"
 import { type ProcessedTickModel, TicksRepository } from "#tick-processing/ticks.repository.ts"
 
 describe("TickProcessor", () => {
-  afterEach(() => {
-    vi.clearAllTimers()
-    vi.useRealTimers()
+  describe("processTicksForever", () => {
+    afterEach(() => {
+      vi.clearAllTimers()
+      vi.useRealTimers()
+    })
+
+    it("should process all currently due ticks before waiting", async () => {
+      // Arrange
+      const db = await createDbMock()
+      const clock = new ControlledClock({ startDate: new Date(0) })
+      const { api, authService, accountsRepository } = await createApiStub({ db, clock })
+      using trpcClient = new TrpcClient({ api })
+
+      authService.account = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
+
+      const tickInterval = Time.create(100, UnitOfTime.SECONDS)
+      const { createdGameId: firstGameId } = await trpcClient.client.lobbies.create.mutate({
+        configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(tickInterval, UnitOfTime.SECONDS) / 2 }),
+      })
+      await trpcClient.client.gameplay.startGame.mutate({ gameId: firstGameId })
+
+      const { createdGameId: secondGameId } = await trpcClient.client.lobbies.create.mutate({
+        configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(tickInterval, UnitOfTime.SECONDS) }),
+      })
+      await trpcClient.client.gameplay.startGame.mutate({ gameId: secondGameId })
+
+      const { tickProcessor } = await createTickProcessorStub({ db, clock })
+
+      // Act
+      vi.useFakeTimers()
+      clock.increment({ time: tickInterval })
+      await tickProcessor.processTicksForever({ interval: Time.create(1, UnitOfTime.SECONDS) })
+
+      // Assert
+      expect(vi.getTimerCount()).toBe(1)
+      vi.clearAllTimers()
+      vi.useRealTimers()
+
+      // Processed twice because the tick interval was smaller than the increment
+      // Simulates a catch-up
+      expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: firstGameId })).toMatchObject({
+        tick: 2,
+        resources: { money: 2 },
+      })
+
+      expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: secondGameId })).toMatchObject({
+        tick: 1,
+        resources: { money: 1 },
+      })
+    })
+
+    it("should wait before retrying when the selected tick processing fails", async () => {
+      // Arrange
+      const db = await createDbMock()
+      const clock = new ControlledClock({ startDate: new Date(0) })
+      const { api, authService, accountsRepository, logger } = await createApiStub({ db, clock })
+      using trpcClient = new TrpcClient({ api })
+
+      authService.account = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
+
+      const tickInterval = Time.create(100, UnitOfTime.SECONDS)
+      const { createdGameId: failingGameId } = await trpcClient.client.lobbies.create.mutate({
+        configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(tickInterval, UnitOfTime.SECONDS) }),
+      })
+      await trpcClient.client.gameplay.startGame.mutate({ gameId: failingGameId })
+
+      const { createdGameId: successfulGameId } = await trpcClient.client.lobbies.create.mutate({
+        configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(tickInterval, UnitOfTime.SECONDS) }),
+      })
+      await trpcClient.client.gameplay.startGame.mutate({ gameId: successfulGameId })
+
+      const ticksRepository = new FailingTicksRepository({ db, logger, clock, failingGameId })
+      const { tickProcessor } = await createTickProcessorStub({ db, clock, ticksRepository })
+
+      // Act
+      vi.useFakeTimers()
+      clock.increment({ time: tickInterval })
+      await tickProcessor.processTicksForever({ interval: Time.create(1, UnitOfTime.SECONDS) })
+
+      // Assert
+      expect(vi.getTimerCount()).toBe(1)
+      vi.clearAllTimers()
+      vi.useRealTimers()
+
+      // No ticks were processed because ticks in error block, this will be resolved by https://github.com/Guillaume-Docquier/text-based-browser-game-1/issues/278
+      expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: failingGameId })).toMatchObject({
+        tick: 0,
+        resources: { money: 0 },
+      })
+
+      expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: successfulGameId })).toMatchObject({
+        tick: 0,
+        resources: { money: 0 },
+      })
+    })
   })
 
-  it("should process the current tick and queue the next one", async () => {
-    // Arrange
-    const db = await createDbMock()
-    const clock = new ControlledClock({ startDate: new Date(0) })
-    const { api, authService, accountsRepository, logger } = await createApiStub({ db, clock })
-    using trpcClient = new TrpcClient({ api })
+  describe("processNextDueTick", () => {
+    it("should process the current tick and queue the next one", async () => {
+      // Arrange
+      const db = await createDbMock()
+      const clock = new ControlledClock({ startDate: new Date(0) })
+      const { api, authService, accountsRepository, logger } = await createApiStub({ db, clock })
+      using trpcClient = new TrpcClient({ api })
 
-    const account = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
-    authService.account = account
+      const account = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
+      authService.account = account
 
-    const tickInterval = Time.create(1000, UnitOfTime.SECONDS)
-    const { createdGameId } = await trpcClient.client.lobbies.create.mutate({
-      configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(tickInterval, UnitOfTime.SECONDS) }),
-    })
+      const tickInterval = Time.create(1000, UnitOfTime.SECONDS)
+      const { createdGameId } = await trpcClient.client.lobbies.create.mutate({
+        configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(tickInterval, UnitOfTime.SECONDS) }),
+      })
 
-    await trpcClient.client.gameplay.startGame.mutate({ gameId: createdGameId })
+      await trpcClient.client.gameplay.startGame.mutate({ gameId: createdGameId })
 
-    const { tickProcessor } = await createTickProcessorStub({ db, clock })
-    const resourcesRepository = new ResourcesRepository({ db, logger })
+      const { tickProcessor } = await createTickProcessorStub({ db, clock })
+      const resourcesRepository = new ResourcesRepository({ db, logger })
 
-    const updateResourceResult = await resourcesRepository.updateResource({
-      gameId: createdGameId,
-      playerId: account.id,
-      resourceType: ResourceType.MONEY,
-      amountDelta: 2,
-    })
-    Assert.isSuccess(updateResourceResult)
-
-    await trpcClient.client.gameplay.setCurrentAction.mutate({
-      gameId: createdGameId,
-      tick: 0,
-      actionType: GamePlayerActionType.MAKE_MORE_MONEY,
-    })
-
-    // Act
-    clock.increment({ time: tickInterval })
-    await tickProcessor.processNextDueTick()
-
-    // Assert
-    const playerView = await trpcClient.client.gameplay.getPlayerView.query({ gameId: createdGameId })
-    expect(playerView).toEqual<typeof playerView>({
-      gameId: createdGameId,
-      playerId: account.id,
-      tick: 1,
-      nextTickAt: Datetime.increment({ date: clock.now(), time: tickInterval }).toISOString(),
-      starSystem: expect.any(Object),
-      resources: {
-        money: 6,
-      },
-    })
-  })
-
-  it("should not apply an action when the player cannot afford it", async () => {
-    // Arrange
-    const db = await createDbMock()
-    const { api, authService, accountsRepository, logger, clock } = await createApiStub({ db })
-    using trpcClient = new TrpcClient({ api })
-
-    const account = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
-    authService.account = account
-    const { createdGameId } = await trpcClient.client.lobbies.create.mutate({
-      configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: 0 }),
-    })
-    await trpcClient.client.gameplay.startGame.mutate({ gameId: createdGameId })
-
-    const { tickProcessor } = await createTickProcessorStub({ db, clock })
-    const resourcesRepository = new ResourcesRepository({ db, logger })
-
-    Assert.isSuccess(
-      await resourcesRepository.updateResource({
+      const updateResourceResult = await resourcesRepository.updateResource({
         gameId: createdGameId,
         playerId: account.id,
         resourceType: ResourceType.MONEY,
         amountDelta: 2,
-      }),
-    )
-    await trpcClient.client.gameplay.setCurrentAction.mutate({
-      gameId: createdGameId,
-      tick: 0,
-      actionType: GamePlayerActionType.MAKE_MORE_MONEY,
-    })
-    Assert.isSuccess(
-      await resourcesRepository.updateResource({
-        gameId: createdGameId,
-        playerId: account.id,
-        resourceType: ResourceType.MONEY,
-        amountDelta: -2,
-      }),
-    )
-
-    // Act
-    await tickProcessor.processNextDueTick()
-
-    // Assert
-    const playerView = await trpcClient.client.gameplay.getPlayerView.query({ gameId: createdGameId })
-    expect(playerView).toMatchObject({
-      tick: 1,
-      resources: {
-        money: 1,
-      },
-    })
-  })
-
-  it("should process only the earliest scheduled tick in one invocation", async () => {
-    // Arrange
-    const db = await createDbMock()
-    const clock = new ControlledClock({ startDate: new Date(0) })
-    const { api, authService, accountsRepository } = await createApiStub({ db, clock })
-    using trpcClient = new TrpcClient({ api })
-
-    authService.account = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
-
-    // later game
-    const laterTickInterval = Time.create(100, UnitOfTime.SECONDS)
-    const { createdGameId: laterGameId } = await trpcClient.client.lobbies.create.mutate({
-      configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(laterTickInterval, UnitOfTime.SECONDS) }),
-    })
-    await trpcClient.client.gameplay.startGame.mutate({ gameId: laterGameId })
-
-    // earlier game
-    const earlierTickInterval = Time.create(50, UnitOfTime.SECONDS)
-    const { createdGameId: earlierGameId } = await trpcClient.client.lobbies.create.mutate({
-      configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(earlierTickInterval, UnitOfTime.SECONDS) }),
-    })
-    await trpcClient.client.gameplay.startGame.mutate({ gameId: earlierGameId })
-
-    const { tickProcessor } = await createTickProcessorStub({ db, clock })
-
-    // Act
-    clock.increment({ time: Time.create(200, UnitOfTime.SECONDS) })
-    await tickProcessor.processNextDueTick()
-
-    // Assert
-    expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: laterGameId })).toMatchObject({
-      tick: 0,
-      resources: { money: 0 },
-    })
-
-    expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: earlierGameId })).toMatchObject({
-      tick: 1,
-      resources: { money: 1 },
-    })
-  })
-
-  it("should process all currently due ticks before waiting", async () => {
-    // Arrange
-    const db = await createDbMock()
-    const clock = new ControlledClock({ startDate: new Date(0) })
-    const { api, authService, accountsRepository } = await createApiStub({ db, clock })
-    using trpcClient = new TrpcClient({ api })
-
-    authService.account = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
-
-    const tickInterval = Time.create(100, UnitOfTime.SECONDS)
-    const { createdGameId: firstGameId } = await trpcClient.client.lobbies.create.mutate({
-      configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(tickInterval, UnitOfTime.SECONDS) }),
-    })
-    await trpcClient.client.gameplay.startGame.mutate({ gameId: firstGameId })
-
-    const { createdGameId: secondGameId } = await trpcClient.client.lobbies.create.mutate({
-      configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(tickInterval, UnitOfTime.SECONDS) }),
-    })
-    await trpcClient.client.gameplay.startGame.mutate({ gameId: secondGameId })
-
-    const { tickProcessor } = await createTickProcessorStub({ db, clock })
-
-    // Act
-    vi.useFakeTimers()
-    clock.increment({ time: tickInterval })
-    await tickProcessor.processTicksForever({ interval: Time.create(1, UnitOfTime.SECONDS) })
-
-    // Assert
-    expect(vi.getTimerCount()).toBe(1)
-    vi.clearAllTimers()
-    vi.useRealTimers()
-
-    expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: firstGameId })).toMatchObject({
-      tick: 1,
-      resources: { money: 1 },
-    })
-
-    expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: secondGameId })).toMatchObject({
-      tick: 1,
-      resources: { money: 1 },
-    })
-  })
-
-  it("should wait before retrying when the selected tick processing fails", async () => {
-    // Arrange
-    const db = await createDbMock()
-    const clock = new ControlledClock({ startDate: new Date(0) })
-    const { api, authService, accountsRepository, logger } = await createApiStub({ db, clock })
-    using trpcClient = new TrpcClient({ api })
-
-    authService.account = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
-
-    const tickInterval = Time.create(100, UnitOfTime.SECONDS)
-    const { createdGameId: failingGameId } = await trpcClient.client.lobbies.create.mutate({
-      configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(tickInterval, UnitOfTime.SECONDS) }),
-    })
-    await trpcClient.client.gameplay.startGame.mutate({ gameId: failingGameId })
-
-    const { createdGameId: successfulGameId } = await trpcClient.client.lobbies.create.mutate({
-      configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(tickInterval, UnitOfTime.SECONDS) }),
-    })
-    await trpcClient.client.gameplay.startGame.mutate({ gameId: successfulGameId })
-
-    const ticksRepository = new FailingTicksRepository({ db, logger, clock, failingGameId })
-    const { tickProcessor } = await createTickProcessorStub({ db, clock, ticksRepository })
-
-    // Act
-    vi.useFakeTimers()
-    clock.increment({ time: tickInterval })
-    await tickProcessor.processTicksForever({ interval: Time.create(1, UnitOfTime.SECONDS) })
-
-    // Assert
-    expect(vi.getTimerCount()).toBe(1)
-    vi.clearAllTimers()
-    vi.useRealTimers()
-
-    expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: failingGameId })).toMatchObject({
-      tick: 0,
-      resources: { money: 0 },
-    })
-
-    expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: successfulGameId })).toMatchObject({
-      tick: 0,
-      resources: { money: 0 },
-    })
-  })
-
-  it("should be able to process the same tick over time", async () => {
-    // Arrange
-    const db = await createDbMock()
-    const clock = new ControlledClock({ startDate: new Date(0) })
-    const { api, authService, accountsRepository } = await createApiStub({ db, clock })
-    using trpcClient = new TrpcClient({ api })
-
-    authService.account = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
-
-    const tickInterval = Time.create(50, UnitOfTime.SECONDS)
-    const { createdGameId: gameId } = await trpcClient.client.lobbies.create.mutate({
-      configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(tickInterval, UnitOfTime.SECONDS) }),
-    })
-    await trpcClient.client.gameplay.startGame.mutate({ gameId })
-
-    const { tickProcessor } = await createTickProcessorStub({ db, clock })
-
-    // Act
-    clock.increment({ time: tickInterval })
-    await tickProcessor.processNextDueTick()
-
-    clock.increment({ time: tickInterval })
-    await tickProcessor.processNextDueTick()
-
-    // Assert
-    expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId })).toMatchObject({
-      tick: 2,
-      resources: { money: 2 },
-    })
-  })
-
-  it("should skip ticks that are already processing", async () => {
-    // Arrange
-    const db = await createDbMock()
-    const clock = new ControlledClock({ startDate: new Date(0) })
-    const { api, authService, accountsRepository } = await createApiStub({ db, clock })
-    using trpcClient = new TrpcClient({ api })
-
-    authService.account = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
-
-    const { tickProcessor, ticksRepository } = await createTickProcessorStub({ db, clock })
-
-    const processingTickInterval = Time.create(50, UnitOfTime.SECONDS)
-    const { createdGameId: processingGameId } = await trpcClient.client.lobbies.create.mutate({
-      configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(processingTickInterval, UnitOfTime.SECONDS) }),
-    })
-    await trpcClient.client.gameplay.startGame.mutate({ gameId: processingGameId })
-    await ticksRepository.startProcessingTick({ gameId: processingGameId, tick: 0 })
-
-    const notProcessingTickInterval = Time.create(100, UnitOfTime.SECONDS)
-    const { createdGameId: notProcessingGameId } = await trpcClient.client.lobbies.create.mutate({
-      configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(notProcessingTickInterval, UnitOfTime.SECONDS) }),
-    })
-    await trpcClient.client.gameplay.startGame.mutate({ gameId: notProcessingGameId })
-
-    // Act
-    clock.increment({ time: notProcessingTickInterval })
-    await tickProcessor.processNextDueTick()
-
-    // Assert
-    expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: processingGameId })).toMatchObject({
-      tick: 0,
-      resources: { money: 0 },
-    })
-
-    expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: notProcessingGameId })).toMatchObject({
-      tick: 1,
-      resources: { money: 1 },
-    })
-  })
-
-  it("should not process another tick when the selected tick processing fails", async () => {
-    // Arrange
-    const db = await createDbMock()
-    const clock = new ControlledClock({ startDate: new Date(0) })
-    const { api, authService, accountsRepository, logger } = await createApiStub({ db, clock })
-    using trpcClient = new TrpcClient({ api })
-
-    authService.account = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
-
-    const failingTickInterval = Time.create(50, UnitOfTime.SECONDS)
-    const { createdGameId: failingGameId } = await trpcClient.client.lobbies.create.mutate({
-      configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(failingTickInterval, UnitOfTime.SECONDS) }),
-    })
-    await trpcClient.client.gameplay.startGame.mutate({ gameId: failingGameId })
-
-    const successfulTickInterval = Time.create(100, UnitOfTime.SECONDS)
-    const { createdGameId: successfulGameId } = await trpcClient.client.lobbies.create.mutate({
-      configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(successfulTickInterval, UnitOfTime.SECONDS) }),
-    })
-    await trpcClient.client.gameplay.startGame.mutate({ gameId: successfulGameId })
-
-    const ticksRepository = new FailingTicksRepository({ db, logger, clock, failingGameId })
-    const { tickProcessor } = await createTickProcessorStub({ db, clock, ticksRepository })
-
-    // Act
-    clock.increment({ time: successfulTickInterval })
-    await tickProcessor.processNextDueTick()
-
-    // Assert
-    expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: failingGameId })).toMatchObject({
-      tick: 0,
-      resources: { money: 0 },
-    })
-
-    expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: successfulGameId })).toMatchObject({
-      tick: 0,
-      resources: { money: 0 },
-    })
-  })
-
-  it("should be able to process ticks in parallel", async () => {
-    // Arrange
-    const db = await createDbMock()
-    const clock = new ControlledClock({ startDate: new Date(0) })
-    const { api, authService, accountsRepository } = await createApiStub({ db, clock })
-    using trpcClient = new TrpcClient({ api })
-
-    authService.account = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
-
-    const earlierTickInterval = Time.create(50, UnitOfTime.SECONDS)
-    const { createdGameId: earlierGameId } = await trpcClient.client.lobbies.create.mutate({
-      configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(earlierTickInterval, UnitOfTime.SECONDS) }),
-    })
-    await trpcClient.client.gameplay.startGame.mutate({ gameId: earlierGameId })
-
-    const laterTickInterval = Time.create(100, UnitOfTime.SECONDS)
-    const { createdGameId: laterGameId } = await trpcClient.client.lobbies.create.mutate({
-      configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(laterTickInterval, UnitOfTime.SECONDS) }),
-    })
-    await trpcClient.client.gameplay.startGame.mutate({ gameId: laterGameId })
-
-    const { tickProcessor } = await createTickProcessorStub({ db, clock })
-
-    // Act
-    clock.increment({ time: laterTickInterval })
-
-    // if rows are locked correctly, processing 2 ticks concurrently should result in 2 different ticks being processed
-    await Promise.all([tickProcessor.processNextDueTick(), tickProcessor.processNextDueTick()])
-
-    // Assert
-    expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: earlierGameId })).toMatchObject({
-      tick: 1,
-      resources: { money: 1 },
-    })
-
-    expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: laterGameId })).toMatchObject({
-      tick: 1,
-      resources: { money: 1 },
-    })
-  })
-
-  it("should do nothing if there are no ticks left when processing ticks in parallel", async () => {
-    // Arrange
-    const db = await createDbMock()
-    const clock = new ControlledClock({ startDate: new Date(0) })
-    const { api, authService, accountsRepository } = await createApiStub({ db, clock })
-    using trpcClient = new TrpcClient({ api })
-
-    authService.account = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
-
-    const tickInterval = Time.create(50, UnitOfTime.SECONDS)
-    const { createdGameId: gameId } = await trpcClient.client.lobbies.create.mutate({
-      configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(tickInterval, UnitOfTime.SECONDS) }),
-    })
-    await trpcClient.client.gameplay.startGame.mutate({ gameId })
-
-    const { tickProcessor } = await createTickProcessorStub({ db, clock })
-
-    // Act
-    clock.increment({ time: tickInterval })
-    // if rows are locked correctly, processing 2 ticks concurrently should result in 1 tick being processed and the other one will do nothing
-    await Promise.all([tickProcessor.processNextDueTick(), tickProcessor.processNextDueTick()])
-
-    // Assert
-    expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId })).toMatchObject({
-      tick: 1,
-      resources: { money: 1 },
-    })
-  })
-
-  it("should fully process every player and select at most one deterministic winner", async () => {
-    // Arrange
-    const db = await createDbMock()
-    const { api, authService, accountsRepository, logger, clock } = await createApiStub({ db })
-    using trpcClient = new TrpcClient({ api })
-
-    const creator = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
-    authService.account = creator
-    const { createdGameId } = await trpcClient.client.lobbies.create.mutate({
-      configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: 0 }),
-    })
-
-    const joiner = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
-    authService.account = joiner
-    await trpcClient.client.lobbies.join.mutate({ gameId: createdGameId })
-
-    authService.account = creator
-    await trpcClient.client.gameplay.startGame.mutate({ gameId: createdGameId })
-
-    const { tickProcessor } = await createTickProcessorStub({ db, clock })
-    const resourcesRepository = new ResourcesRepository({ db, logger })
-
-    for (const { player, amountDelta } of [
-      { player: creator, amountDelta: 10 },
-      { player: joiner, amountDelta: 12 },
-    ]) {
-      const updateResourceResult = await resourcesRepository.updateResource({
-        gameId: createdGameId,
-        playerId: player.id,
-        resourceType: ResourceType.MONEY,
-        amountDelta,
       })
       Assert.isSuccess(updateResourceResult)
 
-      authService.account = player
       await trpcClient.client.gameplay.setCurrentAction.mutate({
         gameId: createdGameId,
         tick: 0,
-        actionType: GamePlayerActionType.WIN_THE_GAME,
+        actionType: GamePlayerActionType.MAKE_MORE_MONEY,
       })
-    }
 
-    // Act
-    await tickProcessor.processNextDueTick()
+      // Act
+      clock.increment({ time: tickInterval })
+      await tickProcessor.processNextDueTick()
 
-    // Assert
-    // Eventually we'll have a turn order that will change during the game, for now the players are sorted by their id
-    const expectedWinnerId = [creator.id, joiner.id].sort()[0]
-
-    const lobby = await trpcClient.client.lobbies.getById.query({ gameId: createdGameId })
-    expect(lobby).toMatchObject({
-      winnerAccountId: expectedWinnerId,
-      endedAt: expect.any(String),
+      // Assert
+      const playerView = await trpcClient.client.gameplay.getPlayerView.query({ gameId: createdGameId })
+      expect(playerView).toEqual<typeof playerView>({
+        gameId: createdGameId,
+        playerId: account.id,
+        tick: 1,
+        nextTickAt: Datetime.increment({ date: clock.now(), time: tickInterval }).toISOString(),
+        starSystem: expect.any(Object),
+        resources: {
+          money: 6,
+        },
+      })
     })
 
-    authService.account = creator
-    const creatorView = await trpcClient.client.gameplay.getPlayerView.query({ gameId: createdGameId })
-    expect(creatorView).toMatchObject({
-      resources: {
-        money: 1,
-      },
+    it("should not apply an action when the player cannot afford it", async () => {
+      // Arrange
+      const db = await createDbMock()
+      const { api, authService, accountsRepository, logger, clock } = await createApiStub({ db })
+      using trpcClient = new TrpcClient({ api })
+
+      const account = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
+      authService.account = account
+      const { createdGameId } = await trpcClient.client.lobbies.create.mutate({
+        configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: 0 }),
+      })
+      await trpcClient.client.gameplay.startGame.mutate({ gameId: createdGameId })
+
+      const { tickProcessor } = await createTickProcessorStub({ db, clock })
+      const resourcesRepository = new ResourcesRepository({ db, logger })
+
+      Assert.isSuccess(
+        await resourcesRepository.updateResource({
+          gameId: createdGameId,
+          playerId: account.id,
+          resourceType: ResourceType.MONEY,
+          amountDelta: 2,
+        }),
+      )
+      await trpcClient.client.gameplay.setCurrentAction.mutate({
+        gameId: createdGameId,
+        tick: 0,
+        actionType: GamePlayerActionType.MAKE_MORE_MONEY,
+      })
+      Assert.isSuccess(
+        await resourcesRepository.updateResource({
+          gameId: createdGameId,
+          playerId: account.id,
+          resourceType: ResourceType.MONEY,
+          amountDelta: -2,
+        }),
+      )
+
+      // Act
+      await tickProcessor.processNextDueTick()
+
+      // Assert
+      const playerView = await trpcClient.client.gameplay.getPlayerView.query({ gameId: createdGameId })
+      expect(playerView).toMatchObject({
+        tick: 1,
+        resources: {
+          money: 1,
+        },
+      })
     })
 
-    authService.account = joiner
-    const joinerView = await trpcClient.client.gameplay.getPlayerView.query({ gameId: createdGameId })
-    expect(joinerView).toMatchObject({
-      resources: {
-        money: 3,
-      },
+    it("should process only the earliest scheduled tick in one invocation", async () => {
+      // Arrange
+      const db = await createDbMock()
+      const clock = new ControlledClock({ startDate: new Date(0) })
+      const { api, authService, accountsRepository } = await createApiStub({ db, clock })
+      using trpcClient = new TrpcClient({ api })
+
+      authService.account = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
+
+      // later game
+      const laterTickInterval = Time.create(100, UnitOfTime.SECONDS)
+      const { createdGameId: laterGameId } = await trpcClient.client.lobbies.create.mutate({
+        configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(laterTickInterval, UnitOfTime.SECONDS) }),
+      })
+      await trpcClient.client.gameplay.startGame.mutate({ gameId: laterGameId })
+
+      // earlier game
+      const earlierTickInterval = Time.create(50, UnitOfTime.SECONDS)
+      const { createdGameId: earlierGameId } = await trpcClient.client.lobbies.create.mutate({
+        configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(earlierTickInterval, UnitOfTime.SECONDS) }),
+      })
+      await trpcClient.client.gameplay.startGame.mutate({ gameId: earlierGameId })
+
+      const { tickProcessor } = await createTickProcessorStub({ db, clock })
+
+      // Act
+      clock.increment({ time: Time.create(200, UnitOfTime.SECONDS) })
+      await tickProcessor.processNextDueTick()
+
+      // Assert
+      expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: laterGameId })).toMatchObject({
+        tick: 0,
+        resources: { money: 0 },
+      })
+
+      expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: earlierGameId })).toMatchObject({
+        tick: 1,
+        resources: { money: 1 },
+      })
     })
-  })
 
-  it("should not do anything in case of failure", async () => {
-    // Arrange
-    const db = await createDbMock()
-    const clock = new ControlledClock({ startDate: new Date(0) })
-    const { api, authService, accountsRepository, logger } = await createApiStub({ db, clock })
-    using trpcClient = new TrpcClient({ api })
+    it("should be able to process the same tick over time", async () => {
+      // Arrange
+      const db = await createDbMock()
+      const clock = new ControlledClock({ startDate: new Date(0) })
+      const { api, authService, accountsRepository } = await createApiStub({ db, clock })
+      using trpcClient = new TrpcClient({ api })
 
-    authService.account = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
+      authService.account = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
 
-    const { createdGameId } = await trpcClient.client.lobbies.create.mutate({
-      configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: 0 }),
+      const tickInterval = Time.create(50, UnitOfTime.SECONDS)
+      const { createdGameId: gameId } = await trpcClient.client.lobbies.create.mutate({
+        configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(tickInterval, UnitOfTime.SECONDS) }),
+      })
+      await trpcClient.client.gameplay.startGame.mutate({ gameId })
+
+      const { tickProcessor } = await createTickProcessorStub({ db, clock })
+
+      // Act
+      clock.increment({ time: tickInterval })
+      await tickProcessor.processNextDueTick()
+
+      clock.increment({ time: tickInterval })
+      await tickProcessor.processNextDueTick()
+
+      // Assert
+      expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId })).toMatchObject({
+        tick: 2,
+        resources: { money: 2 },
+      })
     })
-    await trpcClient.client.gameplay.startGame.mutate({ gameId: createdGameId })
 
-    const ticksRepository = new InvalidPlayerTicksRepository({ db, logger, clock })
-    const { tickProcessor } = await createTickProcessorStub({ db, clock, ticksRepository })
+    it("should skip ticks that are already processing", async () => {
+      // Arrange
+      const db = await createDbMock()
+      const clock = new ControlledClock({ startDate: new Date(0) })
+      const { api, authService, accountsRepository } = await createApiStub({ db, clock })
+      using trpcClient = new TrpcClient({ api })
 
-    const tickToProcess = extractSuccess(await ticksRepository.getNextTickToProcess({ since: clock.now() }))
-    Assert.isDefined(tickToProcess)
+      authService.account = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
 
-    // Act
-    await tickProcessor.processNextDueTick()
+      const { tickProcessor, ticksRepository } = await createTickProcessorStub({ db, clock })
 
-    // Assert
-    await ticksRepository.resetProcessingAttempt(tickToProcess) // This enables getNextTickToProcess to find the tick
-    expect(await ticksRepository.getNextTickToProcess({ since: clock.now() })).toEqual(Result.Success(tickToProcess))
-    expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: createdGameId })).toMatchObject({
-      tick: 0,
-      resources: {
-        money: 0,
-      },
+      const processingTickInterval = Time.create(50, UnitOfTime.SECONDS)
+      const { createdGameId: processingGameId } = await trpcClient.client.lobbies.create.mutate({
+        configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(processingTickInterval, UnitOfTime.SECONDS) }),
+      })
+      await trpcClient.client.gameplay.startGame.mutate({ gameId: processingGameId })
+      await ticksRepository.startProcessingTick({ gameId: processingGameId, tick: 0 })
+
+      const notProcessingTickInterval = Time.create(100, UnitOfTime.SECONDS)
+      const { createdGameId: notProcessingGameId } = await trpcClient.client.lobbies.create.mutate({
+        configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(notProcessingTickInterval, UnitOfTime.SECONDS) }),
+      })
+      await trpcClient.client.gameplay.startGame.mutate({ gameId: notProcessingGameId })
+
+      // Act
+      clock.increment({ time: notProcessingTickInterval })
+      await tickProcessor.processNextDueTick()
+
+      // Assert
+      expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: processingGameId })).toMatchObject({
+        tick: 0,
+        resources: { money: 0 },
+      })
+
+      expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: notProcessingGameId })).toMatchObject({
+        tick: 1,
+        resources: { money: 1 },
+      })
+    })
+
+    it("should not process another tick when the selected tick processing fails", async () => {
+      // Arrange
+      const db = await createDbMock()
+      const clock = new ControlledClock({ startDate: new Date(0) })
+      const { api, authService, accountsRepository, logger } = await createApiStub({ db, clock })
+      using trpcClient = new TrpcClient({ api })
+
+      authService.account = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
+
+      const failingTickInterval = Time.create(50, UnitOfTime.SECONDS)
+      const { createdGameId: failingGameId } = await trpcClient.client.lobbies.create.mutate({
+        configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(failingTickInterval, UnitOfTime.SECONDS) }),
+      })
+      await trpcClient.client.gameplay.startGame.mutate({ gameId: failingGameId })
+
+      const successfulTickInterval = Time.create(100, UnitOfTime.SECONDS)
+      const { createdGameId: successfulGameId } = await trpcClient.client.lobbies.create.mutate({
+        configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(successfulTickInterval, UnitOfTime.SECONDS) }),
+      })
+      await trpcClient.client.gameplay.startGame.mutate({ gameId: successfulGameId })
+
+      const ticksRepository = new FailingTicksRepository({ db, logger, clock, failingGameId })
+      const { tickProcessor } = await createTickProcessorStub({ db, clock, ticksRepository })
+
+      // Act
+      clock.increment({ time: successfulTickInterval })
+      await tickProcessor.processNextDueTick()
+
+      // Assert
+      expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: failingGameId })).toMatchObject({
+        tick: 0,
+        resources: { money: 0 },
+      })
+
+      expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: successfulGameId })).toMatchObject({
+        tick: 0,
+        resources: { money: 0 },
+      })
+    })
+
+    it("should be able to process ticks in parallel", async () => {
+      // Arrange
+      const db = await createDbMock()
+      const clock = new ControlledClock({ startDate: new Date(0) })
+      const { api, authService, accountsRepository } = await createApiStub({ db, clock })
+      using trpcClient = new TrpcClient({ api })
+
+      authService.account = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
+
+      const earlierTickInterval = Time.create(50, UnitOfTime.SECONDS)
+      const { createdGameId: earlierGameId } = await trpcClient.client.lobbies.create.mutate({
+        configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(earlierTickInterval, UnitOfTime.SECONDS) }),
+      })
+      await trpcClient.client.gameplay.startGame.mutate({ gameId: earlierGameId })
+
+      const laterTickInterval = Time.create(100, UnitOfTime.SECONDS)
+      const { createdGameId: laterGameId } = await trpcClient.client.lobbies.create.mutate({
+        configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(laterTickInterval, UnitOfTime.SECONDS) }),
+      })
+      await trpcClient.client.gameplay.startGame.mutate({ gameId: laterGameId })
+
+      const { tickProcessor } = await createTickProcessorStub({ db, clock })
+
+      // Act
+      clock.increment({ time: laterTickInterval })
+
+      // if rows are locked correctly, processing 2 ticks concurrently should result in 2 different ticks being processed
+      await Promise.all([tickProcessor.processNextDueTick(), tickProcessor.processNextDueTick()])
+
+      // Assert
+      expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: earlierGameId })).toMatchObject({
+        tick: 1,
+        resources: { money: 1 },
+      })
+
+      expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: laterGameId })).toMatchObject({
+        tick: 1,
+        resources: { money: 1 },
+      })
+    })
+
+    it("should do nothing if there are no ticks left when processing ticks in parallel", async () => {
+      // Arrange
+      const db = await createDbMock()
+      const clock = new ControlledClock({ startDate: new Date(0) })
+      const { api, authService, accountsRepository } = await createApiStub({ db, clock })
+      using trpcClient = new TrpcClient({ api })
+
+      authService.account = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
+
+      const tickInterval = Time.create(50, UnitOfTime.SECONDS)
+      const { createdGameId: gameId } = await trpcClient.client.lobbies.create.mutate({
+        configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: Time.in(tickInterval, UnitOfTime.SECONDS) }),
+      })
+      await trpcClient.client.gameplay.startGame.mutate({ gameId })
+
+      const { tickProcessor } = await createTickProcessorStub({ db, clock })
+
+      // Act
+      clock.increment({ time: tickInterval })
+      // if rows are locked correctly, processing 2 ticks concurrently should result in 1 tick being processed and the other one will do nothing
+      await Promise.all([tickProcessor.processNextDueTick(), tickProcessor.processNextDueTick()])
+
+      // Assert
+      expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId })).toMatchObject({
+        tick: 1,
+        resources: { money: 1 },
+      })
+    })
+
+    it("should fully process every player and select at most one deterministic winner", async () => {
+      // Arrange
+      const db = await createDbMock()
+      const { api, authService, accountsRepository, logger, clock } = await createApiStub({ db })
+      using trpcClient = new TrpcClient({ api })
+
+      const creator = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
+      authService.account = creator
+      const { createdGameId } = await trpcClient.client.lobbies.create.mutate({
+        configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: 0 }),
+      })
+
+      const joiner = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
+      authService.account = joiner
+      await trpcClient.client.lobbies.join.mutate({ gameId: createdGameId })
+
+      authService.account = creator
+      await trpcClient.client.gameplay.startGame.mutate({ gameId: createdGameId })
+
+      const { tickProcessor } = await createTickProcessorStub({ db, clock })
+      const resourcesRepository = new ResourcesRepository({ db, logger })
+
+      for (const { player, amountDelta } of [
+        { player: creator, amountDelta: 10 },
+        { player: joiner, amountDelta: 12 },
+      ]) {
+        const updateResourceResult = await resourcesRepository.updateResource({
+          gameId: createdGameId,
+          playerId: player.id,
+          resourceType: ResourceType.MONEY,
+          amountDelta,
+        })
+        Assert.isSuccess(updateResourceResult)
+
+        authService.account = player
+        await trpcClient.client.gameplay.setCurrentAction.mutate({
+          gameId: createdGameId,
+          tick: 0,
+          actionType: GamePlayerActionType.WIN_THE_GAME,
+        })
+      }
+
+      // Act
+      await tickProcessor.processNextDueTick()
+
+      // Assert
+      // Eventually we'll have a turn order that will change during the game, for now the players are sorted by their id
+      const expectedWinnerId = [creator.id, joiner.id].sort()[0]
+
+      const lobby = await trpcClient.client.lobbies.getById.query({ gameId: createdGameId })
+      expect(lobby).toMatchObject({
+        winnerAccountId: expectedWinnerId,
+        endedAt: expect.any(String),
+      })
+
+      authService.account = creator
+      const creatorView = await trpcClient.client.gameplay.getPlayerView.query({ gameId: createdGameId })
+      expect(creatorView).toMatchObject({
+        resources: {
+          money: 1,
+        },
+      })
+
+      authService.account = joiner
+      const joinerView = await trpcClient.client.gameplay.getPlayerView.query({ gameId: createdGameId })
+      expect(joinerView).toMatchObject({
+        resources: {
+          money: 3,
+        },
+      })
+    })
+
+    it("should not do anything in case of failure", async () => {
+      // Arrange
+      const db = await createDbMock()
+      const clock = new ControlledClock({ startDate: new Date(0) })
+      const { api, authService, accountsRepository, logger } = await createApiStub({ db, clock })
+      using trpcClient = new TrpcClient({ api })
+
+      authService.account = extractSuccess(await accountsRepository.createAccount(createNewAccountModelStub()))
+
+      const { createdGameId } = await trpcClient.client.lobbies.create.mutate({
+        configuration: createGameConfigurationDtoStub({ tickIntervalSeconds: 0 }),
+      })
+      await trpcClient.client.gameplay.startGame.mutate({ gameId: createdGameId })
+
+      const ticksRepository = new InvalidPlayerTicksRepository({ db, logger, clock })
+      const { tickProcessor } = await createTickProcessorStub({ db, clock, ticksRepository })
+
+      const tickToProcess = extractSuccess(await ticksRepository.getNextTickToProcess({ since: clock.now() }))
+      Assert.isDefined(tickToProcess)
+
+      // Act
+      await tickProcessor.processNextDueTick()
+
+      // Assert
+      await ticksRepository.resetProcessingAttempt(tickToProcess) // This enables getNextTickToProcess to find the tick
+      expect(await ticksRepository.getNextTickToProcess({ since: clock.now() })).toEqual(Result.Success(tickToProcess))
+      expect(await trpcClient.client.gameplay.getPlayerView.query({ gameId: createdGameId })).toMatchObject({
+        tick: 0,
+        resources: {
+          money: 0,
+        },
+      })
     })
   })
 })

--- a/backend/src/tick-processing/TickProcessor.ts
+++ b/backend/src/tick-processing/TickProcessor.ts
@@ -38,6 +38,18 @@ export class TickProcessor {
   }
 
   /**
+   * Processes due ticks until there is no more immediate work, then schedules the next check.
+   */
+  public async processTicksForever({ interval }: { interval: Time }): Promise<void> {
+    let tickProcessingOutcome = await this.processNextDueTick()
+    while (tickProcessingOutcome === "processed") {
+      tickProcessingOutcome = await this.processNextDueTick()
+    }
+
+    setTimeout(() => void this.processTicksForever({ interval }), Time.in(interval, UnitOfTime.MILLISECONDS))
+  }
+
+  /**
    * Processes the next tick that should advance at this point in time.
    * This will resolve all player actions, update the game state and schedule the next tick.
    *
@@ -85,18 +97,6 @@ export class TickProcessor {
       processingLogger.info("Tick processed", { gameId: tickToProcess.gameId, tick: tickToProcess.tick })
       return "processed"
     }
-  }
-
-  /**
-   * Processes due ticks until there is no more immediate work, then schedules the next check.
-   */
-  public async processTicksForever(frequency: number): Promise<void> {
-    let tickProcessingOutcome = await this.processNextDueTick()
-    while (tickProcessingOutcome === "processed") {
-      tickProcessingOutcome = await this.processNextDueTick()
-    }
-
-    setTimeout(() => void this.processTicksForever(frequency), frequency)
   }
 
   private processTick(tickToProcess: TickToProcessModel): ProcessedTickModel {

--- a/backend/src/tick-processing/TickProcessor.ts
+++ b/backend/src/tick-processing/TickProcessor.ts
@@ -9,11 +9,6 @@ import { rollbackOnFailure } from "#lib/errors.ts"
 import { ElapsedTimeContextProvider } from "#tick-processing/ElapsedTimeContextProvider.ts"
 import { type ProcessedTickModel, type TicksRepository, type TickToProcessModel } from "#tick-processing/ticks.repository.ts"
 
-/**
- * The result of trying to process one due tick.
- */
-export type ProcessNextDueTickOutcome = "processed" | "idle" | "failed"
-
 export class TickProcessor {
   private readonly logger: Logger
   private readonly ticksRepository: TicksRepository
@@ -52,10 +47,8 @@ export class TickProcessor {
   /**
    * Processes the next tick that should advance at this point in time.
    * This will resolve all player actions, update the game state and schedule the next tick.
-   *
-   * @returns Whether one tick was processed, no tick was due, or processing failed.
    */
-  public async processNextDueTick(): Promise<ProcessNextDueTickOutcome> {
+  public async processNextDueTick(): Promise<"processed" | "idle" | "failed"> {
     const processingLogger = this.logger.child({ scope: "processNextDueTick", contextProviders: [new ElapsedTimeContextProvider()] })
 
     const tickToProcessResult = await this.createTransaction(async (tx) => {

--- a/backend/src/tick-processing/TickProcessor.ts
+++ b/backend/src/tick-processing/TickProcessor.ts
@@ -9,6 +9,11 @@ import { rollbackOnFailure } from "#lib/errors.ts"
 import { ElapsedTimeContextProvider } from "#tick-processing/ElapsedTimeContextProvider.ts"
 import { type ProcessedTickModel, type TicksRepository, type TickToProcessModel } from "#tick-processing/ticks.repository.ts"
 
+/**
+ * The result of trying to process one due tick.
+ */
+export type ProcessNextDueTickOutcome = "processed" | "idle" | "failed"
+
 export class TickProcessor {
   private readonly logger: Logger
   private readonly ticksRepository: TicksRepository
@@ -35,8 +40,10 @@ export class TickProcessor {
   /**
    * Processes the next tick that should advance at this point in time.
    * This will resolve all player actions, update the game state and schedule the next tick.
+   *
+   * @returns Whether one tick was processed, no tick was due, or processing failed.
    */
-  public async processNextDueTick(): Promise<void> {
+  public async processNextDueTick(): Promise<ProcessNextDueTickOutcome> {
     const processingLogger = this.logger.child({ scope: "processNextDueTick", contextProviders: [new ElapsedTimeContextProvider()] })
 
     const tickToProcessResult = await this.createTransaction(async (tx) => {
@@ -55,13 +62,13 @@ export class TickProcessor {
 
     if (Result.isFailure(tickToProcessResult)) {
       processingLogger.error("Failed to acquire next tick to process", { error: tickToProcessResult.error })
-      return
+      return "failed"
     }
 
     const tickToProcess = tickToProcessResult.value
     if (tickToProcess === undefined) {
       processingLogger.debug("No tick to process")
-      return
+      return "idle"
     }
 
     processingLogger.info("Processing tick", { gameId: tickToProcess.gameId, tick: tickToProcess.tick })
@@ -73,9 +80,23 @@ export class TickProcessor {
         tick: tickToProcess.tick,
         error: saveResult.error,
       })
+      return "failed"
     } else {
       processingLogger.info("Tick processed", { gameId: tickToProcess.gameId, tick: tickToProcess.tick })
+      return "processed"
     }
+  }
+
+  /**
+   * Processes due ticks until there is no more immediate work, then schedules the next check.
+   */
+  public async processTicksForever(frequency: number): Promise<void> {
+    let tickProcessingOutcome = await this.processNextDueTick()
+    while (tickProcessingOutcome === "processed") {
+      tickProcessingOutcome = await this.processNextDueTick()
+    }
+
+    setTimeout(() => void this.processTicksForever(frequency), frequency)
   }
 
   private processTick(tickToProcess: TickToProcessModel): ProcessedTickModel {

--- a/backend/src/tick-processing/entry.tick-processing.ts
+++ b/backend/src/tick-processing/entry.tick-processing.ts
@@ -1,10 +1,10 @@
-import { SHARE_ENV, Worker, isMainThread } from "node:worker_threads"
-import { type Logger, Profile, Time, UnitOfTime } from "@guillaume-docquier/tools-ts"
+import { isMainThread, SHARE_ENV, Worker } from "node:worker_threads"
+import { type Logger, Time, UnitOfTime } from "@guillaume-docquier/tools-ts"
 import { Clock } from "#lib/Clock.ts"
 import { configureLogger } from "#lib/configureLogger.ts"
 import { createCreateTransaction, createDb } from "#lib/db/createDb.ts"
+import { monitorMemoryUsage } from "#lib/monitorMemoryUsage.ts"
 import { envSchema, parseEnv } from "#lib/parseEnv.ts"
-import { repeat } from "#lib/repeat.ts"
 import { TickProcessor } from "#tick-processing/TickProcessor.ts"
 import { TicksRepository } from "#tick-processing/ticks.repository.ts"
 
@@ -49,15 +49,8 @@ if (!isMainThread) {
   const tickProcessor = new TickProcessor({ logger, clock, createTransaction, ticksRepository })
 
   logger.info("Processing ticks forever")
-  await tickProcessor.processTicksForever(1000)
+  // Fire and forget
+  void tickProcessor.processTicksForever({ interval: Time.create(1, UnitOfTime.SECONDS) })
 
-  // We'll capture the memory usage reported by node a few times to compare with what Railway says
-  // There's always a spike at launch, which should settle after a minute or two
-  repeat({
-    times: 5,
-    delay: Time.create(1, UnitOfTime.MINUTES),
-    operation: () => {
-      Profile.memoryUsage(logger)
-    },
-  })
+  monitorMemoryUsage({ logger })
 }

--- a/backend/src/tick-processing/entry.tick-processing.ts
+++ b/backend/src/tick-processing/entry.tick-processing.ts
@@ -49,7 +49,7 @@ if (!isMainThread) {
   const tickProcessor = new TickProcessor({ logger, clock, createTransaction, ticksRepository })
 
   logger.info("Processing ticks forever")
-  await processTicksForever(tickProcessor, 1000)
+  await tickProcessor.processTicksForever(1000)
 
   // We'll capture the memory usage reported by node a few times to compare with what Railway says
   // There's always a spike at launch, which should settle after a minute or two
@@ -60,9 +60,4 @@ if (!isMainThread) {
       Profile.memoryUsage(logger)
     },
   })
-}
-
-async function processTicksForever(tickProcessor: TickProcessor, frequency: number): Promise<void> {
-  await tickProcessor.processNextDueTick()
-  setTimeout(() => void processTicksForever(tickProcessor, frequency), frequency)
 }


### PR DESCRIPTION
## Summary

- Have `TickProcessor.processNextDueTick()` report whether it processed work, found no due tick, or failed.
- Add `TickProcessor.processTicksForever()` so the worker entrypoint is just service construction plus a processor call.
- Cover the draining and failure-delay behavior through `TickProcessor` integration tests using `createTickProcessorStub`.

Closes #279

## Validation

- `pnpm --filter backend checks`
- Focused: `backend/node_modules/.bin/vitest.cmd run --silent=true src/tick-processing/TickProcessor.test.ts`