### PR TITLE
ci: fix release project status lookup

### DIFF
--- a/.github/workflows/release-project-items.yml
+++ b/.github/workflows/release-project-items.yml
@@ -132,6 +132,7 @@ jobs:
                 title
                 fields(first: 100) {
                   nodes {
+                    __typename
                     ... on ProjectV2SingleSelectField {
                       id
                       name
@@ -159,6 +160,16 @@ jobs:
             echo "Could not find project number $PROJECT_NUMBER for $PROJECT_OWNER_TYPE '$PROJECT_OWNER'."
             exit 1
           fi
+
+          echo "Project fields returned by GitHub:"
+          jq --arg ownerField "$project_owner_field" \
+            '.data[$ownerField].projectV2.fields.nodes
+              | map({
+                  type: .__typename,
+                  name: (.name // null),
+                  options: ([.options[]?.name] // [])
+                })' \
+            <<< "$project_json"
 
           status_field_id=$(jq -r \
             --arg ownerField "$project_owner_field" \


### PR DESCRIPTION
## What changed

Fixes the release project item workflow's ProjectV2 status field lookup.

## Root cause

The workflow filtered ProjectV2 fields with `.__typename == "ProjectV2SingleSelectField"`, but the GraphQL query did not request `__typename`. That made the `Status` field lookup always fail, even when the field existed.

## Behavior

- Requests `__typename` in the ProjectV2 fields query.
- Logs returned project fields and single-select options before looking up the configured status field, so future config/API mismatches are easier to diagnose.

## Verification

- `git diff --check -- .github/workflows/release-project-items.yml`
- `pnpm exec oxfmt --check .github/workflows/release-project-items.yml`