### PR TITLE
backend: added load tests with real Postgres and test harness

### DIFF
--- a/backend/src/api/accounts/accounts.repository.ts
+++ b/backend/src/api/accounts/accounts.repository.ts
@@ -51,6 +51,25 @@ export class AccountsRepository extends PostgresRepository {
     return createAccountResult
   }
 
+  public async getAccountById(
+    { accountId }: { accountId: AccountId },
+    db: PostgresRepository["db"] = this.db,
+  ): Promise<Result<AccountModel | undefined, string>> {
+    const findByIdResult = await Result.tryCatch(async () => {
+      const accounts = await db.select().from(accountsTable).where(eq(accountsTable.id, accountId))
+      Assert.isTrue(accounts.length <= 1)
+
+      return accounts[0]
+    })
+
+    if (Result.isFailure(findByIdResult)) {
+      this.logger.error("Could not get account by id", { accountId, error: findByIdResult.error })
+      return Result.Failure(couldNot("get account by id"))
+    }
+
+    return findByIdResult
+  }
+
   /**
    * Gets an account by the auth id.
    * Returns undefined when no matching account was found.

--- a/backend/src/api/lobbies/lobbies.load.test.ts
+++ b/backend/src/api/lobbies/lobbies.load.test.ts
@@ -1,0 +1,86 @@
+import { Logger } from "@guillaume-docquier/tools-ts"
+import { describe, expect, it } from "vitest"
+import { createNewAccountModelStub } from "#api/accounts/NewAccountModel.stub.ts"
+import { createGameConfigurationDtoStub } from "#api/lobbies/GameConfigurationDto.stub.ts"
+import { type LobbyPlayerDto } from "#api/lobbies/lobbies.controller.ts"
+import { GameStatus } from "#api/shared/GameStatus.ts"
+import { STARTING_RESOURCE_AMOUNTS } from "#lib/db/gameplay/gameResources.ts"
+import { extractSuccess } from "#tests/extractSuccess.ts"
+import { createLoadTestApi } from "#tests/load/loadTestApi.ts"
+import { ResourcesRepository } from "#tests/resources/resources.repository.ts"
+
+const RACING_ACCOUNTS_COUNT = 20
+const LIMITED_SEAT_COUNT = 4
+
+async function ignoreExpectedRaceFailure(operation: Promise<unknown>): Promise<void> {
+  await operation.catch(() => undefined)
+}
+
+describe("lobbies load tests", () => {
+  it("should not allow concurrent joins beyond the game seat count", async () => {
+    await using loadTestApi = await createLoadTestApi()
+    const creator = extractSuccess(await loadTestApi.accountsRepository.createAccount(createNewAccountModelStub({ alias: "Creator" })))
+    const accounts = await Promise.all(
+      Array.from({ length: RACING_ACCOUNTS_COUNT }, async (_, index) =>
+        extractSuccess(await loadTestApi.accountsRepository.createAccount(createNewAccountModelStub({ alias: `Player ${index}` }))),
+      ),
+    )
+
+    using creatorClient = loadTestApi.trpcClientForAccount(creator.id)
+    const { createdGameId } = await creatorClient.client.lobbies.create.mutate({
+      configuration: createGameConfigurationDtoStub({ nbSeats: LIMITED_SEAT_COUNT }),
+    })
+
+    await Promise.all(
+      accounts.map(async (account) => {
+        using client = loadTestApi.trpcClientForAccount(account.id)
+        await ignoreExpectedRaceFailure(client.client.lobbies.join.mutate({ gameId: createdGameId }))
+      }),
+    )
+
+    const lobby = await creatorClient.client.lobbies.getById.query({ gameId: createdGameId })
+    expect(lobby.players).toHaveLength(LIMITED_SEAT_COUNT)
+  })
+
+  it("should keep started game players and starting resources consistent during concurrent joins and leaves", async () => {
+    await using loadTestApi = await createLoadTestApi()
+    const creator = extractSuccess(await loadTestApi.accountsRepository.createAccount(createNewAccountModelStub({ alias: "Creator" })))
+    const accounts = await Promise.all(
+      Array.from({ length: RACING_ACCOUNTS_COUNT }, async (_, index) =>
+        extractSuccess(await loadTestApi.accountsRepository.createAccount(createNewAccountModelStub({ alias: `Player ${index}` }))),
+      ),
+    )
+
+    using creatorClient = loadTestApi.trpcClientForAccount(creator.id)
+    const { createdGameId } = await creatorClient.client.lobbies.create.mutate({
+      configuration: createGameConfigurationDtoStub({ nbSeats: RACING_ACCOUNTS_COUNT + 1 }),
+    })
+
+    await Promise.all([
+      creatorClient.client.gameplay.startGame.mutate({ gameId: createdGameId }),
+      ...accounts.map(async (account) => {
+        using client = loadTestApi.trpcClientForAccount(account.id)
+        await ignoreExpectedRaceFailure(client.client.lobbies.join.mutate({ gameId: createdGameId }))
+        await ignoreExpectedRaceFailure(client.client.lobbies.leave.mutate({ gameId: createdGameId }))
+      }),
+    ])
+
+    const lobby = await creatorClient.client.lobbies.getById.query({ gameId: createdGameId })
+    expect(lobby.status).toBe(GameStatus.STARTED)
+
+    const resourcesRepository = new ResourcesRepository({ logger: Logger.get(), db: loadTestApi.db })
+    const resources = extractSuccess(await resourcesRepository.getResourcesByGameId({ gameId: createdGameId }))
+    const playerIds = new Set(lobby.players.map((player: LobbyPlayerDto) => player.id))
+    const startingResourceAmounts = Object.values(STARTING_RESOURCE_AMOUNTS).sort((left, right) => left - right)
+
+    expect(resources.every((resource) => playerIds.has(resource.playerId))).toBe(true)
+    expect(
+      lobby.players.map((player) =>
+        resources
+          .filter((resource) => resource.playerId === player.id)
+          .map((resource) => resource.amount)
+          .sort((left, right) => left - right),
+      ),
+    ).toEqual(lobby.players.map(() => startingResourceAmounts))
+  })
+})

--- a/backend/src/tests/HeaderAuthService.ts
+++ b/backend/src/tests/HeaderAuthService.ts
@@ -1,0 +1,38 @@
+import type { RequestHandler } from "express"
+import type { AccountsRepository } from "#api/accounts/accounts.repository.ts"
+import type { IAuthService } from "#api/accounts/auth.service.ts"
+import type { AccountId } from "#lib/db/accounts/AccountId.ts"
+import { extractSuccess } from "#tests/extractSuccess.ts"
+
+export const TEST_ACCOUNT_ID_HEADER = "x-test-account-id"
+
+/**
+ * Test-only auth service that maps a request header to a real account from the database.
+ *
+ * This keeps concurrent API tests independent from shared mutable auth state while still
+ * exercising the production express/tRPC stack.
+ */
+export class HeaderAuthService implements IAuthService {
+  private readonly accountsRepository: AccountsRepository
+
+  public constructor({ accountsRepository }: { accountsRepository: AccountsRepository }) {
+    this.accountsRepository = accountsRepository
+  }
+
+  public authenticationMiddlewares(): RequestHandler[] {
+    return [
+      async (req, _res, next): Promise<void> => {
+        const accountId = req.headers[TEST_ACCOUNT_ID_HEADER]
+        if (typeof accountId !== "string") {
+          req.account = undefined
+          next()
+          return
+        }
+
+        const account = extractSuccess(await this.accountsRepository.getAccountById({ accountId: accountId }))
+        req.account = account
+        next()
+      },
+    ]
+  }
+}

--- a/backend/src/tests/TrpcClient.ts
+++ b/backend/src/tests/TrpcClient.ts
@@ -25,13 +25,19 @@ export class TrpcClient {
   public readonly client
   private readonly server
 
-  public constructor({ api }: { api: Express }) {
+  public constructor({ api, headers }: { api: Express; headers?: () => Record<string, string> }) {
     this.server = createServer(api)
     this.server.listen(ANY_UNUSED_PORT)
     const address = this.server.address() as AddressInfo
 
     this.client = createTRPCClient<TrpcRouter>({
-      links: [httpBatchLink({ url: `http://localhost:${address.port}/trpc` })],
+      links: [
+        httpBatchLink(
+          headers === undefined
+            ? { url: `http://localhost:${address.port}/trpc` }
+            : { url: `http://localhost:${address.port}/trpc`, headers },
+        ),
+      ],
     })
   }
 

--- a/backend/src/tests/load/PostgresTestContainer.ts
+++ b/backend/src/tests/load/PostgresTestContainer.ts
@@ -1,0 +1,99 @@
+import { request } from "node:http"
+
+const DOCKER_SOCKET_PATH = "/var/run/docker.sock"
+const POSTGRES_PORT = "5432/tcp"
+const POSTGRES_IMAGE = "postgres:18"
+
+type DockerContainerInspect = {
+  NetworkSettings: {
+    Ports: Record<string, Array<{ HostIp: string; HostPort: string }> | null>
+  }
+}
+
+export class PostgresTestContainer {
+  private containerId: string | undefined
+
+  public async start(): Promise<string> {
+    await dockerRequest({ method: "POST", path: `/images/create?fromImage=${encodeURIComponent(POSTGRES_IMAGE)}` })
+
+    const createResponse = await dockerRequest<{ Id: string }>({
+      method: "POST",
+      path: "/containers/create",
+      body: {
+        Image: POSTGRES_IMAGE,
+        Env: ["POSTGRES_DB=cosmic_empires_test", "POSTGRES_PASSWORD=postgres", "POSTGRES_USER=postgres"],
+        ExposedPorts: { [POSTGRES_PORT]: {} },
+        HostConfig: { PublishAllPorts: true },
+      },
+    })
+    this.containerId = createResponse.Id
+
+    await dockerRequest({ method: "POST", path: `/containers/${this.containerId}/start` })
+    const hostPort = await this.waitForMappedPort()
+
+    return `postgres://postgres:postgres@127.0.0.1:${hostPort}/cosmic_empires_test`
+  }
+
+  public async stop(): Promise<void> {
+    if (this.containerId === undefined) {
+      return
+    }
+
+    await dockerRequest({ method: "DELETE", path: `/containers/${this.containerId}?force=true&v=true` })
+  }
+
+  private async waitForMappedPort(): Promise<string> {
+    for (let attempt = 0; attempt < 60; attempt += 1) {
+      const inspect = await dockerRequest<DockerContainerInspect>({ method: "GET", path: `/containers/${this.containerId}/json` })
+      const binding = inspect.NetworkSettings.Ports[POSTGRES_PORT]?.[0]
+      if (binding !== undefined) {
+        return binding.HostPort
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 250))
+    }
+
+    throw new Error("Postgres test container did not expose a port in time.")
+  }
+}
+
+async function dockerRequest<TResponse = unknown>({
+  method,
+  path,
+  body,
+}: {
+  method: string
+  path: string
+  body?: unknown
+}): Promise<TResponse> {
+  return new Promise((resolve, reject) => {
+    const requestBody = body === undefined ? undefined : JSON.stringify(body)
+    const req = request(
+      {
+        socketPath: DOCKER_SOCKET_PATH,
+        path,
+        method,
+        headers:
+          requestBody === undefined ? undefined : { "content-type": "application/json", "content-length": Buffer.byteLength(requestBody) },
+      },
+      (res) => {
+        const chunks: Buffer[] = []
+        res.on("data", (chunk: Buffer) => chunks.push(chunk))
+        res.on("end", () => {
+          const responseText = Buffer.concat(chunks).toString("utf8")
+          if (res.statusCode !== undefined && res.statusCode >= 400) {
+            reject(new Error(`Docker API request failed with ${res.statusCode}: ${responseText}`))
+            return
+          }
+
+          resolve(responseText.length === 0 ? (undefined as TResponse) : (JSON.parse(responseText) as TResponse))
+        })
+      },
+    )
+    req.on("error", reject)
+    if (requestBody !== undefined) {
+      req.write(requestBody)
+    }
+    req.end()
+  })
+}

--- a/backend/src/tests/load/loadTestApi.ts
+++ b/backend/src/tests/load/loadTestApi.ts
@@ -1,0 +1,53 @@
+import { Logger } from "@guillaume-docquier/tools-ts"
+import { migrate } from "drizzle-orm/node-postgres/migrator"
+import { AccountsRepository } from "#api/accounts/accounts.repository.ts"
+import { createApi } from "#api/createApi.ts"
+import { GameplayRepository } from "#api/gameplay/gameplay.repository.ts"
+import { ListingsRepository } from "#api/listings/listings.repository.ts"
+import { LobbiesRepository } from "#api/lobbies/lobbies.repository.ts"
+import { Clock } from "#lib/Clock.ts"
+import { createCreateTransaction, createDb, type Database } from "#lib/db/createDb.ts"
+import { HeaderAuthService, TEST_ACCOUNT_ID_HEADER } from "#tests/HeaderAuthService.ts"
+import { PostgresTestContainer } from "#tests/load/PostgresTestContainer.ts"
+import { TrpcClient } from "#tests/TrpcClient.ts"
+
+export type LoadTestApi = Awaited<ReturnType<typeof createLoadTestApi>>
+
+export async function createLoadTestApi(): Promise<{
+  db: Database
+  accountsRepository: AccountsRepository
+  lobbiesRepository: LobbiesRepository
+  trpcClientForAccount: (accountId: string) => TrpcClient
+  [Symbol.asyncDispose]: () => Promise<void>
+}> {
+  const postgresContainer = new PostgresTestContainer()
+  const databaseUrl = await postgresContainer.start()
+  const logger = Logger.get()
+  const db = createDb({ databaseUrl })
+
+  await migrate(db, { migrationsFolder: "./drizzle/" })
+
+  const accountsRepository = new AccountsRepository({ db, logger })
+  const lobbiesRepository = new LobbiesRepository({ db, logger })
+  const api = await createApi({
+    logger,
+    clock: Clock,
+    authService: new HeaderAuthService({ accountsRepository }),
+    createTransaction: createCreateTransaction(db),
+    accountsRepository,
+    listingsRepository: new ListingsRepository({ db, logger }),
+    lobbiesRepository,
+    gameplayRepository: new GameplayRepository({ db, logger, clock: Clock }),
+  })
+
+  return {
+    db,
+    accountsRepository,
+    lobbiesRepository,
+    trpcClientForAccount: (accountId): TrpcClient =>
+      new TrpcClient({ api, headers: (): Record<string, string> => ({ [TEST_ACCOUNT_ID_HEADER]: accountId }) }),
+    [Symbol.asyncDispose]: async () => {
+      await postgresContainer.stop()
+    },
+  }
+}

--- a/backend/src/tests/resources/resources.repository.ts
+++ b/backend/src/tests/resources/resources.repository.ts
@@ -7,6 +7,13 @@ import { PostgresRepository } from "#lib/db/PostgresRepository.ts"
 import { resourcesTable } from "#lib/db/schema.ts"
 import { couldNot } from "#lib/errors.ts"
 
+export type ResourceModel = {
+  gameId: GameId
+  playerId: PlayerId
+  resourceType: ResourceType
+  amount: number
+}
+
 export type ResourceUpdateModel = {
   gameId: GameId
   playerId: PlayerId
@@ -23,6 +30,20 @@ export class ResourcesRepository extends PostgresRepository {
   public constructor({ logger, db }: { logger: Logger; db: PostgresRepository["db"] }) {
     super({ db })
     this.logger = logger.child({ scope: "game-player-resources-repository" })
+  }
+
+  public async getResourcesByGameId(
+    { gameId }: { gameId: GameId },
+    db: PostgresRepository["db"] = this.db,
+  ): Promise<Result<ResourceModel[], string>> {
+    const getResourcesResult = await Result.tryCatch(db.select().from(resourcesTable).where(eq(resourcesTable.gameId, gameId)))
+
+    if (Result.isFailure(getResourcesResult)) {
+      this.logger.error("Could not get resources for game", { gameId, error: getResourcesResult.error })
+      return Result.Failure(couldNot("get resources for game"))
+    }
+
+    return Result.Success(getResourcesResult.value as ResourceModel[])
   }
 
   public async updateResource(resourceUpdate: ResourceUpdateModel, db: PostgresRepository["db"] = this.db): Promise<Result<true, string>> {

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vitest/config"
 
 const integrationTestsInclude = ["src/**/*.router.test.ts", "src/**/TickProcessor.test.ts"]
+const loadTestsInclude = ["src/**/*.load.test.ts"]
 
 export default defineConfig({
   test: {
@@ -23,7 +24,16 @@ export default defineConfig({
           include: ["src/**/*.test.ts"],
           // I would do something like .unit.test.ts and .integration.test.ts without exclude
           // However, this breaks WebStorm's "Go to test" and it cannot be configured...
-          exclude: integrationTestsInclude,
+          exclude: [...integrationTestsInclude, ...loadTestsInclude],
+        },
+      },
+      {
+        // load tests use a containerized real postgres
+        extends: true,
+        test: {
+          name: { label: "load", color: "yellow" },
+          include: loadTestsInclude,
+          testTimeout: 60_000,
         },
       },
       {


### PR DESCRIPTION
### Motivation
- Add non-mocked load tests that exercise the real backend and a real Postgres instance to surface concurrency and locking issues in the lobby/start flow.
- Keep DX: make `pnpm --filter backend test` run the load tests alongside existing unit/integration projects so the harness and tests run in CI when Docker is available.

### Description
- Add two load tests at `src/api/lobbies/lobbies.load.test.ts` that simulate 20 concurrent accounts racing to join a limited-seat game and concurrent join/leave while the creator starts the game.  
- Add a lightweight load-test API harness in `src/tests/load/loadTestApi.ts` that starts Postgres, runs Drizzle migrations, boots the real Express/tRPC app in-process, and exposes `trpcClientForAccount`.  
- Provide a container helper `src/tests/load/PostgresTestContainer.ts` that talks to the Docker daemon via `/var/run/docker.sock` to start/stop a Postgres image for tests.  
- Add `HeaderAuthService` in `src/tests/HeaderAuthService.ts` and extend `TrpcClient` to accept per-client headers so concurrent test clients map to real accounts without mutating shared test auth state.  
- Add small repository helpers: `AccountsRepository.getAccountById` and `ResourcesRepository.getResourcesByGameId` to support the load-test assertions, and update `vitest.config.ts` to run `*.load.test.ts` as a separate `load` project.  

### Testing
- Ran TypeScript checks with `tsgo` and `pnpm --filter backend typecheck`, which succeeded.  
- Ran the new load test file with `vitest` (`./backend/node_modules/.bin/vitest run --silent=true src/api/lobbies/lobbies.load.test.ts`), which failed in this environment because the Docker socket is unavailable (`connect ENOENT /var/run/docker.sock`).  
- Ran the full backend test suite (`pnpm --filter backend test`) in this environment and observed the new load tests fail for the same reason while the existing unit/integration tests executed (existing unit/integration tests passed, the two new load tests failed).  
- The failure is expected in this environment; the load tests require Docker to start Postgres and are intended to surface concurrency defects in the DB/locking logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49a2370b50832da92f7fe3a55a886f)