### PR TITLE
backend: log memory usage every minute, no cap

### DIFF
--- a/backend/src/lib/monitorMemoryUsage.ts
+++ b/backend/src/lib/monitorMemoryUsage.ts
@@ -1,14 +1,11 @@
-import { type Logger, Profile, Time, UnitOfTime } from "@guillaume-docquier/tools-ts"
-import { repeat } from "#lib/repeat.ts"
+import { type Logger, Profile } from "@guillaume-docquier/tools-ts"
 
+/**
+ * Logs memory usage snapshots to compare with what Railway says
+ * The memory used as reported by node is smaller than what Railway is billing me by quite a margin... (like billed 230MB when RSS is at 150MB)
+ */
 export function monitorMemoryUsage({ logger }: { logger: Logger }): void {
-  // We'll capture the memory usage reported by node a few times to compare with what Railway says
-  // There's always a spike at launch, which should settle after a minute or two
-  repeat({
-    times: 5,
-    delay: Time.create(1, UnitOfTime.MINUTES),
-    operation: () => {
-      Profile.memoryUsage(logger)
-    },
-  })
+  setInterval(() => {
+    Profile.memoryUsage(logger)
+  }, 60_000)
 }


### PR DESCRIPTION
I need to see how it evolves. There's definitely a gap in the first 5 minutes, what about 1 day in?