### PR TITLE
project: pnpm 11.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,5 @@
       "onFail": "download"
     }
   },
-  "packageManager": "pnpm@11.9.0"
+  "packageManager": "pnpm@11.11.0"
 }


### PR DESCRIPTION
- pnpm `11.12.0` fails to update because https://github.com/pnpm/pnpm/issues/12959
- pnpm `11.13.0` fails to update with `[...]\@pnpm\exe\pnpm"' is not recognized as an internal or external command`. Did not find an issue about this, people are probably stuck on 11.11.0 anyways

First time having issues with pnpm like this, kinda lame that it fails when installing...
