### PR TITLE
backend: prevent turn quickfire after downtime

### DIFF
--- a/backend/src/turn-processing/TurnProcessor.test.ts
+++ b/backend/src/turn-processing/TurnProcessor.test.ts
@@ -19,47 +19,6 @@ describe("TurnProcessor", () => {
       vi.useRealTimers()
     })
 
-    it("should process all currently due turns before waiting", async () => {
-      // Arrange
-      const db = await createDbMock()
-      const clock = new ControlledClock({ startDate: new Date(0) })
-      using apiServer = new ApiServer(await createApiStub({ db, clock }))
-      const player = await apiServer.createClient({ authenticated: true })
-
-      const turnInterval = Time.create(100, UnitOfTime.SECONDS)
-      const { createdGameId: firstGameId } = await player.client.lobbies.create.mutate({
-        configuration: createGameConfigurationDtoStub({ turnIntervalSeconds: Time.in(turnInterval, UnitOfTime.SECONDS) / 2 }),
-      })
-      await player.client.gameplay.startGame.mutate({ gameId: firstGameId })
-
-      const { createdGameId: secondGameId } = await player.client.lobbies.create.mutate({
-        configuration: createGameConfigurationDtoStub({ turnIntervalSeconds: Time.in(turnInterval, UnitOfTime.SECONDS) }),
-      })
-      await player.client.gameplay.startGame.mutate({ gameId: secondGameId })
-
-      const { turnProcessor } = await createTurnProcessorStub({ db, clock })
-
-      // Act
-      vi.useFakeTimers()
-      clock.increment({ time: turnInterval })
-      await turnProcessor.processTurnsForever({ interval: Time.create(1, UnitOfTime.SECONDS) })
-
-      // Assert
-      expect(vi.getTimerCount()).toBe(1)
-      vi.clearAllTimers()
-      vi.useRealTimers()
-
-      expect(await player.client.gameplay.getPlayerView.query({ gameId: firstGameId })).toMatchObject({
-        turn: 1,
-        resources: { money: 1 },
-      })
-
-      expect(await player.client.gameplay.getPlayerView.query({ gameId: secondGameId })).toMatchObject({
-        turn: 1,
-        resources: { money: 1 },
-      })
-    })
-
     it("should wait before retrying when the selected turn processing fails", async () => {
       // Arrange
       const db = await createDbMock()

--- a/backend/src/turn-processing/TurnProcessor.test.ts
+++ b/backend/src/turn-processing/TurnProcessor.test.ts
@@ -49,11 +49,9 @@ describe("TurnProcessor", () => {
       vi.clearAllTimers()
       vi.useRealTimers()
 
-      // Processed twice because the turn interval was smaller than the increment
-      // Simulates a catch-up
       expect(await player.client.gameplay.getPlayerView.query({ gameId: firstGameId })).toMatchObject({
-        turn: 2,
-        resources: { money: 2 },
+        turn: 1,
+        resources: { money: 1 },
       })
 
       expect(await player.client.gameplay.getPlayerView.query({ gameId: secondGameId })).toMatchObject({
@@ -156,6 +154,58 @@ describe("TurnProcessor", () => {
         resources: {
           money: 6,
         },
+      })
+    })
+
+    it("should schedule the next turn from the current time when the delay exceeds 15 percent of the interval", async () => {
+      // Arrange
+      const db = await createDbMock()
+      const clock = new ControlledClock({ startDate: new Date(0) })
+      using apiServer = new ApiServer(await createApiStub({ db, clock }))
+      const player = await apiServer.createClient({ authenticated: true })
+
+      const turnInterval = Time.create(100, UnitOfTime.SECONDS)
+      const { createdGameId } = await player.client.lobbies.create.mutate({
+        configuration: createGameConfigurationDtoStub({ turnIntervalSeconds: Time.in(turnInterval, UnitOfTime.SECONDS) }),
+      })
+      await player.client.gameplay.startGame.mutate({ gameId: createdGameId })
+
+      const { turnProcessor } = await createTurnProcessorStub({ db, clock })
+
+      // Act
+      clock.increment({ time: Time.create(120, UnitOfTime.SECONDS) })
+      await turnProcessor.processNextDueTurn()
+
+      // Assert
+      expect(await player.client.gameplay.getPlayerView.query({ gameId: createdGameId })).toMatchObject({
+        turn: 1,
+        nextTurnAt: Datetime.increment({ date: clock.now(), time: turnInterval }).toISOString(),
+      })
+    })
+
+    it("should cap the delay threshold at two minutes", async () => {
+      // Arrange
+      const db = await createDbMock()
+      const clock = new ControlledClock({ startDate: new Date(0) })
+      using apiServer = new ApiServer(await createApiStub({ db, clock }))
+      const player = await apiServer.createClient({ authenticated: true })
+
+      const turnInterval = Time.create(1000, UnitOfTime.SECONDS)
+      const { createdGameId } = await player.client.lobbies.create.mutate({
+        configuration: createGameConfigurationDtoStub({ turnIntervalSeconds: Time.in(turnInterval, UnitOfTime.SECONDS) }),
+      })
+      await player.client.gameplay.startGame.mutate({ gameId: createdGameId })
+
+      const { turnProcessor } = await createTurnProcessorStub({ db, clock })
+
+      // Act
+      clock.increment({ time: Time.create(1200, UnitOfTime.SECONDS) })
+      await turnProcessor.processNextDueTurn()
+
+      // Assert
+      expect(await player.client.gameplay.getPlayerView.query({ gameId: createdGameId })).toMatchObject({
+        turn: 1,
+        nextTurnAt: Datetime.increment({ date: clock.now(), time: turnInterval }).toISOString(),
       })
     })
 

--- a/backend/src/turn-processing/TurnProcessor.test.ts
+++ b/backend/src/turn-processing/TurnProcessor.test.ts
@@ -19,6 +19,47 @@ describe("TurnProcessor", () => {
       vi.useRealTimers()
     })
 
+    it("should process all currently due turns before waiting", async () => {
+      // Arrange
+      const db = await createDbMock()
+      const clock = new ControlledClock({ startDate: new Date(0) })
+      using apiServer = new ApiServer(await createApiStub({ db, clock }))
+      const player = await apiServer.createClient({ authenticated: true })
+
+      const turnInterval = Time.create(100, UnitOfTime.SECONDS)
+      const { createdGameId: firstGameId } = await player.client.lobbies.create.mutate({
+        configuration: createGameConfigurationDtoStub({ turnIntervalSeconds: Time.in(turnInterval, UnitOfTime.SECONDS) / 2 }),
+      })
+      await player.client.gameplay.startGame.mutate({ gameId: firstGameId })
+
+      const { createdGameId: secondGameId } = await player.client.lobbies.create.mutate({
+        configuration: createGameConfigurationDtoStub({ turnIntervalSeconds: Time.in(turnInterval, UnitOfTime.SECONDS) }),
+      })
+      await player.client.gameplay.startGame.mutate({ gameId: secondGameId })
+
+      const { turnProcessor } = await createTurnProcessorStub({ db, clock })
+
+      // Act
+      vi.useFakeTimers()
+      clock.increment({ time: turnInterval })
+      await turnProcessor.processTurnsForever({ interval: Time.create(1, UnitOfTime.SECONDS) })
+
+      // Assert
+      expect(vi.getTimerCount()).toBe(1)
+      vi.clearAllTimers()
+      vi.useRealTimers()
+
+      expect(await player.client.gameplay.getPlayerView.query({ gameId: firstGameId })).toMatchObject({
+        turn: 1,
+        resources: { money: 1 },
+      })
+
+      expect(await player.client.gameplay.getPlayerView.query({ gameId: secondGameId })).toMatchObject({
+        turn: 1,
+        resources: { money: 1 },
+      })
+    })
+
     it("should wait before retrying when the selected turn processing fails", async () => {
       // Arrange
       const db = await createDbMock()
@@ -116,57 +157,36 @@ describe("TurnProcessor", () => {
       })
     })
 
-    it("should schedule the next turn from the current time when the delay exceeds 15 percent of the interval", async () => {
-      // Arrange
-      const db = await createDbMock()
-      const clock = new ControlledClock({ startDate: new Date(0) })
-      using apiServer = new ApiServer(await createApiStub({ db, clock }))
-      const player = await apiServer.createClient({ authenticated: true })
+    it.each([
+      { turnInterval: Time.create(100, UnitOfTime.SECONDS), timeIncrement: Time.create(116, UnitOfTime.SECONDS) },
+      { turnInterval: Time.create(100, UnitOfTime.MINUTES), timeIncrement: Time.create(103, UnitOfTime.MINUTES) },
+    ])(
+      "should schedule the next turn from the current time when the delay exceeds 15 percent of the interval, capped at 2 minutes",
+      async ({ turnInterval, timeIncrement }) => {
+        // Arrange
+        const db = await createDbMock()
+        const clock = new ControlledClock({ startDate: new Date(0) })
+        using apiServer = new ApiServer(await createApiStub({ db, clock }))
+        const player = await apiServer.createClient({ authenticated: true })
 
-      const turnInterval = Time.create(100, UnitOfTime.SECONDS)
-      const { createdGameId } = await player.client.lobbies.create.mutate({
-        configuration: createGameConfigurationDtoStub({ turnIntervalSeconds: Time.in(turnInterval, UnitOfTime.SECONDS) }),
-      })
-      await player.client.gameplay.startGame.mutate({ gameId: createdGameId })
+        const { createdGameId } = await player.client.lobbies.create.mutate({
+          configuration: createGameConfigurationDtoStub({ turnIntervalSeconds: Time.in(turnInterval, UnitOfTime.SECONDS) }),
+        })
+        await player.client.gameplay.startGame.mutate({ gameId: createdGameId })
 
-      const { turnProcessor } = await createTurnProcessorStub({ db, clock })
+        const { turnProcessor } = await createTurnProcessorStub({ db, clock })
 
-      // Act
-      clock.increment({ time: Time.create(120, UnitOfTime.SECONDS) })
-      await turnProcessor.processNextDueTurn()
+        // Act
+        clock.increment({ time: timeIncrement })
+        await turnProcessor.processNextDueTurn()
 
-      // Assert
-      expect(await player.client.gameplay.getPlayerView.query({ gameId: createdGameId })).toMatchObject({
-        turn: 1,
-        nextTurnAt: Datetime.increment({ date: clock.now(), time: turnInterval }).toISOString(),
-      })
-    })
-
-    it("should cap the delay threshold at two minutes", async () => {
-      // Arrange
-      const db = await createDbMock()
-      const clock = new ControlledClock({ startDate: new Date(0) })
-      using apiServer = new ApiServer(await createApiStub({ db, clock }))
-      const player = await apiServer.createClient({ authenticated: true })
-
-      const turnInterval = Time.create(1000, UnitOfTime.SECONDS)
-      const { createdGameId } = await player.client.lobbies.create.mutate({
-        configuration: createGameConfigurationDtoStub({ turnIntervalSeconds: Time.in(turnInterval, UnitOfTime.SECONDS) }),
-      })
-      await player.client.gameplay.startGame.mutate({ gameId: createdGameId })
-
-      const { turnProcessor } = await createTurnProcessorStub({ db, clock })
-
-      // Act
-      clock.increment({ time: Time.create(1200, UnitOfTime.SECONDS) })
-      await turnProcessor.processNextDueTurn()
-
-      // Assert
-      expect(await player.client.gameplay.getPlayerView.query({ gameId: createdGameId })).toMatchObject({
-        turn: 1,
-        nextTurnAt: Datetime.increment({ date: clock.now(), time: turnInterval }).toISOString(),
-      })
-    })
+        // Assert
+        expect(await player.client.gameplay.getPlayerView.query({ gameId: createdGameId })).toMatchObject({
+          turn: 1,
+          nextTurnAt: Datetime.increment({ date: clock.now(), time: turnInterval }).toISOString(),
+        })
+      },
+    )
 
     it("should not apply an action when the player cannot afford it", async () => {
       // Arrange

--- a/backend/src/turn-processing/TurnProcessor.ts
+++ b/backend/src/turn-processing/TurnProcessor.ts
@@ -11,6 +11,9 @@ import { rollbackOnFailure, TransactionRollback } from "#lib/errors.ts"
 import { ElapsedTimeContextProvider } from "#turn-processing/ElapsedTimeContextProvider.ts"
 import { type ProcessedTurnModel, type TurnsRepository, type TurnToProcessModel } from "#turn-processing/turns.repository.ts"
 
+const SCHEDULE_DRIFT_RATIO = 0.15
+const MAX_SCHEDULE_DRIFT_MILLISECONDS = 2 * 60 * 1000
+
 export class TurnProcessor {
   private readonly logger: Logger
   private readonly turnsRepository: TurnsRepository
@@ -138,10 +141,11 @@ export class TurnProcessor {
       return processedPlayers
     }, {})
 
+    const processedAt = this.clock.now()
     const turnResult: Omit<ProcessedTurnModel, "gameStatus"> = {
       gameId: turnToProcess.gameId,
       turn: turnToProcess.turn,
-      processedAt: this.clock.now(),
+      processedAt,
       playerResources: Object.entries(playerStates).flatMap(([playerId, playerResources]) =>
         playerResources.map((resource) => ({ ...resource, playerId })),
       ),
@@ -153,9 +157,10 @@ export class TurnProcessor {
         gameStatus: GameStatus.COLLECTING_ACTIONS,
         nextTurn: {
           turn: turnToProcess.turn + 1,
-          scheduledFor: Datetime.increment({
-            date: turnToProcess.scheduledFor,
-            time: Time.create(turnToProcess.turnIntervalSeconds, UnitOfTime.SECONDS),
+          scheduledFor: getNextTurnScheduledFor({
+            scheduledFor: turnToProcess.scheduledFor,
+            processedAt,
+            turnIntervalSeconds: turnToProcess.turnIntervalSeconds,
           }),
         },
       }
@@ -168,4 +173,24 @@ export class TurnProcessor {
       endedAt: this.clock.now(),
     }
   }
+}
+
+function getNextTurnScheduledFor({
+  scheduledFor,
+  processedAt,
+  turnIntervalSeconds,
+}: {
+  scheduledFor: Date
+  processedAt: Date
+  turnIntervalSeconds: number
+}): Date {
+  const turnIntervalMilliseconds = turnIntervalSeconds * 1000
+  const scheduleDriftMilliseconds = processedAt.getTime() - scheduledFor.getTime()
+  const scheduleDriftThresholdMilliseconds = Math.min(turnIntervalMilliseconds * SCHEDULE_DRIFT_RATIO, MAX_SCHEDULE_DRIFT_MILLISECONDS)
+  const scheduleFrom = scheduleDriftMilliseconds > scheduleDriftThresholdMilliseconds ? processedAt : scheduledFor
+
+  return Datetime.increment({
+    date: scheduleFrom,
+    time: Time.create(turnIntervalSeconds, UnitOfTime.SECONDS),
+  })
 }

--- a/backend/src/turn-processing/TurnProcessor.ts
+++ b/backend/src/turn-processing/TurnProcessor.ts
@@ -175,6 +175,10 @@ export class TurnProcessor {
   }
 }
 
+/**
+ * Schedules from the persisted time for normal drift, but from the processing time after a significant delay so server downtime cannot cause
+ * turns to resolve back-to-back when the server returns.
+ */
 function getNextTurnScheduledFor({
   scheduledFor,
   processedAt,

--- a/backend/src/turn-processing/TurnProcessor.ts
+++ b/backend/src/turn-processing/TurnProcessor.ts
@@ -12,7 +12,7 @@ import { ElapsedTimeContextProvider } from "#turn-processing/ElapsedTimeContextP
 import { type ProcessedTurnModel, type TurnsRepository, type TurnToProcessModel } from "#turn-processing/turns.repository.ts"
 
 const SCHEDULE_DRIFT_RATIO = 0.15
-const MAX_SCHEDULE_DRIFT_MILLISECONDS = 2 * 60 * 1000
+const MAX_SCHEDULE_DRIFT = Time.create(2 * 60 * 1000, UnitOfTime.MILLISECONDS)
 
 export class TurnProcessor {
   private readonly logger: Logger
@@ -160,7 +160,7 @@ export class TurnProcessor {
           scheduledFor: getNextTurnScheduledFor({
             scheduledFor: turnToProcess.scheduledFor,
             processedAt,
-            turnIntervalSeconds: turnToProcess.turnIntervalSeconds,
+            turnInterval: turnToProcess.turnInterval,
           }),
         },
       }
@@ -178,19 +178,22 @@ export class TurnProcessor {
 function getNextTurnScheduledFor({
   scheduledFor,
   processedAt,
-  turnIntervalSeconds,
+  turnInterval,
 }: {
   scheduledFor: Date
   processedAt: Date
-  turnIntervalSeconds: number
+  turnInterval: Time
 }): Date {
-  const turnIntervalMilliseconds = turnIntervalSeconds * 1000
+  const turnIntervalMilliseconds = Time.in(turnInterval, UnitOfTime.MILLISECONDS)
   const scheduleDriftMilliseconds = processedAt.getTime() - scheduledFor.getTime()
-  const scheduleDriftThresholdMilliseconds = Math.min(turnIntervalMilliseconds * SCHEDULE_DRIFT_RATIO, MAX_SCHEDULE_DRIFT_MILLISECONDS)
-  const scheduleFrom = scheduleDriftMilliseconds > scheduleDriftThresholdMilliseconds ? processedAt : scheduledFor
+  const scheduleDriftThreshold = Math.min(
+    turnIntervalMilliseconds * SCHEDULE_DRIFT_RATIO,
+    Time.in(MAX_SCHEDULE_DRIFT, UnitOfTime.MILLISECONDS),
+  )
+  const scheduleFrom = scheduleDriftMilliseconds > scheduleDriftThreshold ? processedAt : scheduledFor
 
   return Datetime.increment({
     date: scheduleFrom,
-    time: Time.create(turnIntervalSeconds, UnitOfTime.SECONDS),
+    time: turnInterval,
   })
 }

--- a/backend/src/turn-processing/TurnProcessor.ts
+++ b/backend/src/turn-processing/TurnProcessor.ts
@@ -12,7 +12,7 @@ import { ElapsedTimeContextProvider } from "#turn-processing/ElapsedTimeContextP
 import { type ProcessedTurnModel, type TurnsRepository, type TurnToProcessModel } from "#turn-processing/turns.repository.ts"
 
 const SCHEDULE_DRIFT_RATIO = 0.15
-const MAX_SCHEDULE_DRIFT = Time.create(2 * 60 * 1000, UnitOfTime.MILLISECONDS)
+const MAX_SCHEDULE_DRIFT_MS = Time.in(Time.create(2, UnitOfTime.MINUTES), UnitOfTime.MILLISECONDS)
 
 export class TurnProcessor {
   private readonly logger: Logger
@@ -176,8 +176,8 @@ export class TurnProcessor {
 }
 
 /**
- * Schedules from the persisted time for normal drift, but from the processing time after a significant delay so server downtime cannot cause
- * turns to resolve back-to-back when the server returns.
+ * Schedules from the processing time when we detect a schedule time drift.
+ * This avoids quick-firing turn processing if there is a server downtime.
  */
 function getNextTurnScheduledFor({
   scheduledFor,
@@ -188,12 +188,8 @@ function getNextTurnScheduledFor({
   processedAt: Date
   turnInterval: Time
 }): Date {
-  const turnIntervalMilliseconds = Time.in(turnInterval, UnitOfTime.MILLISECONDS)
   const scheduleDriftMilliseconds = processedAt.getTime() - scheduledFor.getTime()
-  const scheduleDriftThreshold = Math.min(
-    turnIntervalMilliseconds * SCHEDULE_DRIFT_RATIO,
-    Time.in(MAX_SCHEDULE_DRIFT, UnitOfTime.MILLISECONDS),
-  )
+  const scheduleDriftThreshold = Math.min(Time.in(turnInterval, UnitOfTime.MILLISECONDS) * SCHEDULE_DRIFT_RATIO, MAX_SCHEDULE_DRIFT_MS)
   const scheduleFrom = scheduleDriftMilliseconds > scheduleDriftThreshold ? processedAt : scheduledFor
 
   return Datetime.increment({

--- a/backend/src/turn-processing/turns.repository.ts
+++ b/backend/src/turn-processing/turns.repository.ts
@@ -1,4 +1,4 @@
-import { Assert, branded, type Branded, type Logger, Result } from "@guillaume-docquier/tools-ts"
+import { Assert, branded, type Branded, type Logger, Result, Time, UnitOfTime } from "@guillaume-docquier/tools-ts"
 import { and, asc, eq, isNull, lte, sql } from "drizzle-orm"
 import type { GameId } from "#api/shared/GameId.ts"
 import type { PlayerId } from "#api/shared/PlayerId.ts"
@@ -41,7 +41,7 @@ export type TurnToProcessModel = {
   gameId: GameId
   turn: number
   scheduledFor: Date
-  turnIntervalSeconds: number
+  turnInterval: Time
   players: Record<
     PlayerId,
     {
@@ -177,7 +177,7 @@ export class TurnsRepository extends PostgresRepository {
       return toTurnToProcessModel({
         turnForProcessing: startTurnProcessingModel.turn,
         scheduledFor: turns[0].scheduledFor,
-        turnIntervalSeconds: games[0].turnIntervalSeconds,
+        turnInterval: Time.create(games[0].turnIntervalSeconds, UnitOfTime.SECONDS),
         players,
         resources,
         actions,
@@ -295,14 +295,14 @@ export class TurnsRepository extends PostgresRepository {
 function toTurnToProcessModel({
   turnForProcessing,
   scheduledFor,
-  turnIntervalSeconds,
+  turnInterval,
   players,
   resources,
   actions,
 }: {
   turnForProcessing: TurnForProcessing
   scheduledFor: Date
-  turnIntervalSeconds: number
+  turnInterval: Time
   players: PlayerRow[]
   resources: ResourceRow[]
   actions: ActionRow[]
@@ -313,7 +313,7 @@ function toTurnToProcessModel({
   return {
     ...turnForProcessing,
     scheduledFor,
-    turnIntervalSeconds,
+    turnInterval,
     players: players.reduce<TurnToProcessModel["players"]>((playersById, { playerId }) => {
       const resourcesForPlayer = resourcesByPlayerId.get(playerId)
       Assert.isDefined(resourcesForPlayer)


### PR DESCRIPTION
## What changed

When a turn is processed late, the next turn now uses the current time as its scheduling anchor when drift exceeds `min(15% of the turn interval, 2 minutes)`. Smaller delays preserve the existing schedule cadence.

The turn-processing integration tests cover both the percentage threshold and the two-minute cap, and the old quick-fire catch-up expectation now verifies that a missed turn does not immediately trigger another turn.

## Why

A server outage could leave scheduled turns overdue. The processor would then queue each next turn from the old scheduled timestamp and resolve turns back-to-back when the server returned, preventing players from meaningfully playing.

## Validation

- `pnpm --filter backend checks` (typecheck and 74 backend tests)
- `pnpm exec oxlint --max-warnings 0 backend/src/turn-processing/TurnProcessor.ts backend/src/turn-processing/TurnProcessor.test.ts`
- `pnpm exec oxfmt backend/src/turn-processing/TurnProcessor.ts backend/src/turn-processing/TurnProcessor.test.ts`

Closes #77