### PR TITLE
frontend: stabilize galaxy e2e with seeded game

### DIFF
--- a/frontend/playwright/pages/CreateGamePage.ts
+++ b/frontend/playwright/pages/CreateGamePage.ts
@@ -12,7 +12,6 @@ export class CreateGamePage {
   public readonly maxPlayersInput: Locator
   public readonly turnLengthInput: Locator
   public readonly turnLengthUnitSelect: Locator
-  public readonly generationSeedInput: Locator
   public readonly createButton: Locator
 
   public constructor(page: Page) {
@@ -23,18 +22,18 @@ export class CreateGamePage {
     this.maxPlayersInput = page.getByRole("spinbutton", { name: "Max number of players" })
     this.turnLengthInput = page.getByRole("spinbutton", { name: "Turn length" })
     this.turnLengthUnitSelect = page.getByRole("combobox", { name: "Turn length unit" })
-    this.generationSeedInput = page.getByRole("spinbutton", { name: "Generation seed" })
     this.createButton = page.getByRole("button", { name: "Create", exact: true })
   }
 
-  public static async goto(page: Page): Promise<CreateGamePage> {
+  public static async goto(page: Page, options?: { seed: number }): Promise<CreateGamePage> {
     const createGamePage = new CreateGamePage(page)
-    await createGamePage.goto()
+    await createGamePage.goto(options)
     return createGamePage
   }
 
-  public async goto(): Promise<void> {
-    await this.page.goto(CreateGamePage.urlPattern.pathname)
+  public async goto(options?: { seed: number }): Promise<void> {
+    const seedSearch = options === undefined ? "" : `?seed=${options.seed}`
+    await this.page.goto(`${CreateGamePage.urlPattern.pathname}${seedSearch}`)
   }
 
   public async setGameName(name: string): Promise<void> {
@@ -63,10 +62,6 @@ export class CreateGamePage {
       await this.setSliderValue(minimumSlider, min)
       await this.setSliderValue(maximumSlider, max)
     }
-  }
-
-  public async setGenerationSeed(seed: number): Promise<void> {
-    await this.generationSeedInput.fill(seed.toString())
   }
 
   public async submit(): Promise<void> {

--- a/frontend/playwright/specs/lobbies.spec.ts
+++ b/frontend/playwright/specs/lobbies.spec.ts
@@ -5,6 +5,8 @@ import { GalaxyPage } from "../pages/GalaxyPage.ts"
 import { LobbyPage } from "../pages/LobbyPage.ts"
 import { SignInPage } from "../pages/SignInPage.ts"
 
+const DETERMINISTIC_GALAXY_SEED = 1234
+
 test.describe("anonymous user", () => {
   test("must sign in to create a game", async ({ page }) => {
     await CreateGamePage.goto(page)
@@ -32,7 +34,7 @@ test.describe("authenticated user", () => {
   })
 
   test("creates and starts a game", async ({ page }) => {
-    const createGamePage = await CreateGamePage.goto(page)
+    const createGamePage = await CreateGamePage.goto(page, { seed: DETERMINISTIC_GALAXY_SEED })
     const gameName = `Playwright game ${Date.now()}`
 
     await test.step("Configure the game", async () => {
@@ -92,13 +94,14 @@ test.describe("authenticated user", () => {
       const cameraScaleBeforeInspecting = await galaxyPage.getGalaxyCameraScale()
 
       await selectedStar.press("Enter")
-      await expect(galaxyPage.starSystemMap).not.toBeVisible()
       await expect(galaxyPage.starSystemMap).toBeVisible()
 
       const firstPlanet = galaxyPage.planets.first()
       const secondPlanet = galaxyPage.planets.nth(1)
       const firstPlanetName = await galaxyPage.getPlanetName(firstPlanet)
       const secondPlanetName = await galaxyPage.getPlanetName(secondPlanet)
+      expect(firstPlanetName).toBe("planet 122350")
+      expect(secondPlanetName).toBe("planet 983117")
 
       await firstPlanet.press("Enter")
       await expect(galaxyPage.planetDetailsPane).toBeVisible()

--- a/frontend/src/features/games/CreateGamePage.tsx
+++ b/frontend/src/features/games/CreateGamePage.tsx
@@ -18,7 +18,7 @@ const TurnIntervalUnit = {
   minutes: "minutes",
 } as const
 
-export function CreateGamePage(): ReactElement {
+export function CreateGamePage({ seed }: { seed: number | undefined }): ReactElement {
   const creationSettingsQuery = useLobbyCreationSettingsQuery()
 
   if (creationSettingsQuery.isPending || creationSettingsQuery.isFetching) {
@@ -33,10 +33,16 @@ export function CreateGamePage(): ReactElement {
     )
   }
 
-  return <CreateGameForm creationSettings={creationSettingsQuery.data} />
+  return <CreateGameForm creationSettings={creationSettingsQuery.data} seed={seed} />
 }
 
-function CreateGameForm({ creationSettings }: { creationSettings: ApiTypes.LobbyCreationSettings }): ReactElement {
+function CreateGameForm({
+  creationSettings,
+  seed,
+}: {
+  creationSettings: ApiTypes.LobbyCreationSettings
+  seed: number | undefined
+}): ReactElement {
   const [name, setName] = useState("")
   const [nbSeats, setNbSeats] = useState(5)
   const [turnIntervalMultiplier, setTurnIntervalMultiplier] = useState(1)
@@ -121,6 +127,7 @@ function CreateGameForm({ creationSettings }: { creationSettings: ApiTypes.Lobby
                 name,
                 nbSeats,
                 turnIntervalSeconds: Temporal.Duration.from({ [turnIntervalUnit]: turnIntervalMultiplier }).total("seconds"),
+                ...(seed === undefined ? {} : { seed }),
               },
             })
           }}

--- a/frontend/src/routes/_site.games.create.tsx
+++ b/frontend/src/routes/_site.games.create.tsx
@@ -1,8 +1,20 @@
 import { createFileRoute } from "@tanstack/react-router"
+import type { ReactElement } from "react"
+import { z } from "zod"
 import { CreateGamePage } from "@/features/games/CreateGamePage.tsx"
 import { privateRoute } from "@/privateRoute.ts"
 
-export const Route = createFileRoute("/_site/games/create")({
-  component: CreateGamePage,
-  beforeLoad: privateRoute,
+const CreateGameSearch = z.object({
+  seed: z.number().exactOptional(),
 })
+
+export const Route = createFileRoute("/_site/games/create")({
+  component: CreateGameRoute,
+  beforeLoad: privateRoute,
+  validateSearch: CreateGameSearch,
+})
+
+function CreateGameRoute(): ReactElement {
+  const { seed } = Route.useSearch()
+  return <CreateGamePage seed={seed} />
+}


### PR DESCRIPTION
## Summary

Adds a hidden `seed` query parameter to the create-game flow and uses it to make the Galaxy E2E scenario deterministic while preserving the primary mouse interaction.

## Root cause and impact

The test created a random Galaxy, so the Planet details pane could cover the second randomly positioned Planet and intercept its click. It also asserted a transient hidden state that could be missed entirely.

The seeded scenario fixes both timing assumptions without changing the visible create-game UI or production defaults.

## Validation

- `pnpm --filter frontend checks` — typecheck, production build, Storybook build, and all 8 E2E tests passed
- affected Playwright scenario repeated 5 times serially — 5/5 passed
- pre-commit oxlint and oxfmt hooks passed

Fixes #361