### PR TITLE
project: expose uncommitted resources

### DIFF
--- a/backend/src/api/gameplay/ResourcesDto.stub.ts
+++ b/backend/src/api/gameplay/ResourcesDto.stub.ts
@@ -1,0 +1,13 @@
+import type { ResourcesDto } from "#api/gameplay/ResourcesDto.ts"
+import { ResourceType } from "#lib/rules-engine/ruleset-model/mechanics/ResourceType.ts"
+
+export function createResourcesDtoStub(overrides?: Partial<ResourcesDto>): ResourcesDto {
+  return {
+    [ResourceType.INFLUENCE]: { total: 0, uncommitted: 0 },
+    [ResourceType.METAL]: { total: 0, uncommitted: 0 },
+    [ResourceType.FUEL]: { total: 0, uncommitted: 0 },
+    [ResourceType.ENERGY]: { total: 0, uncommitted: 0 },
+    [ResourceType.COLONY]: { total: 0, uncommitted: 0 },
+    ...overrides,
+  }
+}

--- a/backend/src/api/gameplay/ResourcesDto.ts
+++ b/backend/src/api/gameplay/ResourcesDto.ts
@@ -1,0 +1,17 @@
+import { z } from "zod"
+import { ResourceTypeSchema } from "#lib/rules-engine/ruleset-model/mechanics/ResourceType.ts"
+
+export type ResourceAmountsDto = z.infer<typeof ResourceAmountsDtoSchema>
+const ResourceAmountsDtoSchema = z.object({
+  /**
+   * Resources that can be used this turn on more actions.
+   */
+  uncommitted: z.number(),
+  /**
+   * All resources that are available this turn, including those already committed to actions.
+   */
+  total: z.number(),
+})
+
+export type ResourcesDto = z.infer<typeof ResourcesDtoSchema>
+export const ResourcesDtoSchema = z.record(ResourceTypeSchema, ResourceAmountsDtoSchema)

--- a/backend/src/api/gameplay/gameplay.controller.ts
+++ b/backend/src/api/gameplay/gameplay.controller.ts
@@ -262,8 +262,7 @@ function toPlayerViewDto(playerViewModel: PlayerViewModel): PlayerViewDto {
     },
     turn: playerViewModel.turn,
     nextTurnAt: playerViewModel.nextTurnAt,
-    resources: playerViewModel.resources,
-    uncommittedResources,
+    resources: toResourcesDto(playerViewModel.resources, uncommittedResources),
     ruleset: playerViewModel.ruleset,
     availableActions: createAvailableActions(playerViewModel, uncommittedResources),
   }
@@ -277,11 +276,26 @@ function getUncommittedResources(playerViewModel: PlayerViewModel): Record<Resou
     Assert.isDefined(actionDefinition)
 
     for (const cost of actionDefinition.costs) {
-      uncommittedResources[cost.resourceType] = Math.max(0, uncommittedResources[cost.resourceType] - cost.quantity)
+      const uncommittedQuantity = uncommittedResources[cost.resourceType] - cost.quantity
+      Assert.isTrue(uncommittedQuantity >= 0)
+      uncommittedResources[cost.resourceType] = uncommittedQuantity
     }
   }
 
   return uncommittedResources
+}
+
+function toResourcesDto(
+  totalResources: Record<ResourceType, number>,
+  uncommittedResources: Record<ResourceType, number>,
+): PlayerViewDto["resources"] {
+  const resourceEntries = Object.values(ResourceType).map((resourceType) => [
+    resourceType,
+    { uncommitted: uncommittedResources[resourceType], total: totalResources[resourceType] },
+  ])
+
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- SAFETY: resourceEntries contains exactly one entry for every ResourceType.
+  return Object.fromEntries(resourceEntries) as PlayerViewDto["resources"]
 }
 
 function createAvailableActions(
@@ -404,6 +418,8 @@ type ActionSubmissionDto = z.infer<typeof ActionSubmissionDto>
 const AvailableActionDto = ActionSubmissionDto.extend({ canAfford: z.boolean() })
 type AvailableActionDto = z.infer<typeof AvailableActionDto>
 
+const ResourceAmountsDto = z.object({ uncommitted: z.number(), total: z.number() })
+
 export type PlayerViewDto = z.infer<typeof PlayerViewDto>
 export const PlayerViewDto = z.object({
   gameId: GameId,
@@ -412,8 +428,7 @@ export const PlayerViewDto = z.object({
   galaxy: GalaxyDto,
   turn: z.number(),
   nextTurnAt: z.date(),
-  resources: z.record(ResourceTypeSchema, z.number()),
-  uncommittedResources: z.record(ResourceTypeSchema, z.number()),
+  resources: z.record(ResourceTypeSchema, ResourceAmountsDto),
   ruleset: RulesetSchema,
   availableActions: z.array(AvailableActionDto),
 })

--- a/backend/src/api/gameplay/gameplay.controller.ts
+++ b/backend/src/api/gameplay/gameplay.controller.ts
@@ -1,6 +1,7 @@
 import { Assert, Rng, Datetime, type Logger, mulberry32Prng, Result, Timer } from "@guillaume-docquier/tools-ts"
 import { v4 } from "uuid"
 import z from "zod"
+import { type ResourceAmountsDto, ResourcesDtoSchema } from "#api/gameplay/ResourcesDto.ts"
 import { GalaxySettings } from "#api/shared/GalaxySettings.ts"
 import { GameId } from "#api/shared/GameId.ts"
 import { PlanetCoordinates, toPlanetCoordinates } from "#api/shared/PlanetCoordinates.ts"
@@ -20,7 +21,7 @@ import type { ActionSubmission } from "#lib/rules-engine/action-submission/Actio
 import { validateActionSubmissions } from "#lib/rules-engine/action-submission/validation/validateActionSubmissions.ts"
 import { validateCosts } from "#lib/rules-engine/action-submission/validation/validators/validateCosts.ts"
 import { ActionDefinitionIdSchema } from "#lib/rules-engine/ruleset-model/actions/ActionDefinition.ts"
-import { ResourceType, ResourceTypeSchema } from "#lib/rules-engine/ruleset-model/mechanics/ResourceType.ts"
+import { ResourceType } from "#lib/rules-engine/ruleset-model/mechanics/ResourceType.ts"
 import { RulesetSchema } from "#lib/rules-engine/ruleset-model/Ruleset.ts"
 import type { TurnState } from "#lib/rules-engine/turn-resolution/TurnState.ts"
 import { UInt32 } from "#lib/UInt32.ts"
@@ -115,6 +116,8 @@ export class GameplayController {
     }
 
     if (playerViewResult.value === undefined) {
+      // This is not a Failure because everything went right.
+      // It's a bad request, but not unexpected from here that no player view is found.
       return Result.Success(undefined)
     }
 
@@ -271,14 +274,13 @@ function toPlayerViewDto(playerViewModel: PlayerViewModel): PlayerViewDto {
 function getUncommittedResources(playerViewModel: PlayerViewModel): Record<ResourceType, number> {
   const uncommittedResources = { ...playerViewModel.resources }
 
-  for (const actionSubmission of playerViewModel.actionSubmissions) {
+  for (const actionSubmission of playerViewModel.actions) {
     const actionDefinition = playerViewModel.ruleset.actionDefinitions[actionSubmission.actionDefinitionId]
     Assert.isDefined(actionDefinition)
 
     for (const cost of actionDefinition.costs) {
-      const uncommittedQuantity = uncommittedResources[cost.resourceType] - cost.quantity
-      Assert.isTrue(uncommittedQuantity >= 0)
-      uncommittedResources[cost.resourceType] = uncommittedQuantity
+      uncommittedResources[cost.resourceType] -= cost.quantity
+      Assert.isTrue(uncommittedResources[cost.resourceType] >= 0)
     }
   }
 
@@ -286,16 +288,18 @@ function getUncommittedResources(playerViewModel: PlayerViewModel): Record<Resou
 }
 
 function toResourcesDto(
-  totalResources: Record<ResourceType, number>,
-  uncommittedResources: Record<ResourceType, number>,
+  totalResources: Readonly<Record<ResourceType, number>>,
+  uncommittedResources: Readonly<Record<ResourceType, number>>,
 ): PlayerViewDto["resources"] {
-  const resourceEntries = Object.values(ResourceType).map((resourceType) => [
-    resourceType,
-    { uncommitted: uncommittedResources[resourceType], total: totalResources[resourceType] },
-  ])
-
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- SAFETY: resourceEntries contains exactly one entry for every ResourceType.
-  return Object.fromEntries(resourceEntries) as PlayerViewDto["resources"]
+  // string instead of ResourceType to satisfy TypeScript. Strange that it works, maybe even dangerous, but okay
+  return Object.entries(totalResources).reduce<Record<string, ResourceAmountsDto>>((resourcesDto, [resourceType, total]) => {
+    resourcesDto[resourceType] = {
+      total,
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Object.entries widens the key type.
+      uncommitted: uncommittedResources[resourceType as ResourceType] ?? 0,
+    }
+    return resourcesDto
+  }, {})
 }
 
 function createAvailableActions(
@@ -418,8 +422,6 @@ type ActionSubmissionDto = z.infer<typeof ActionSubmissionDto>
 const AvailableActionDto = ActionSubmissionDto.extend({ canAfford: z.boolean() })
 type AvailableActionDto = z.infer<typeof AvailableActionDto>
 
-const ResourceAmountsDto = z.object({ uncommitted: z.number(), total: z.number() })
-
 export type PlayerViewDto = z.infer<typeof PlayerViewDto>
 export const PlayerViewDto = z.object({
   gameId: GameId,
@@ -428,7 +430,7 @@ export const PlayerViewDto = z.object({
   galaxy: GalaxyDto,
   turn: z.number(),
   nextTurnAt: z.date(),
-  resources: z.record(ResourceTypeSchema, ResourceAmountsDto),
+  resources: ResourcesDtoSchema,
   ruleset: RulesetSchema,
   availableActions: z.array(AvailableActionDto),
 })

--- a/backend/src/api/gameplay/gameplay.controller.ts
+++ b/backend/src/api/gameplay/gameplay.controller.ts
@@ -248,6 +248,8 @@ function createGalaxy(seed: number): GalaxyModel {
 }
 
 function toPlayerViewDto(playerViewModel: PlayerViewModel): PlayerViewDto {
+  const uncommittedResources = getUncommittedResources(playerViewModel)
+
   return {
     gameId: playerViewModel.gameId,
     player: playerViewModel.player,
@@ -261,15 +263,34 @@ function toPlayerViewDto(playerViewModel: PlayerViewModel): PlayerViewDto {
     turn: playerViewModel.turn,
     nextTurnAt: playerViewModel.nextTurnAt,
     resources: playerViewModel.resources,
+    uncommittedResources,
     ruleset: playerViewModel.ruleset,
-    availableActions: createAvailableActions(playerViewModel),
+    availableActions: createAvailableActions(playerViewModel, uncommittedResources),
   }
 }
 
-function createAvailableActions(playerViewModel: PlayerViewModel): AvailableActionDto[] {
+function getUncommittedResources(playerViewModel: PlayerViewModel): Record<ResourceType, number> {
+  const uncommittedResources = { ...playerViewModel.resources }
+
+  for (const actionSubmission of playerViewModel.actionSubmissions) {
+    const actionDefinition = playerViewModel.ruleset.actionDefinitions[actionSubmission.actionDefinitionId]
+    Assert.isDefined(actionDefinition)
+
+    for (const cost of actionDefinition.costs) {
+      uncommittedResources[cost.resourceType] = Math.max(0, uncommittedResources[cost.resourceType] - cost.quantity)
+    }
+  }
+
+  return uncommittedResources
+}
+
+function createAvailableActions(
+  playerViewModel: PlayerViewModel,
+  uncommittedResources: Record<ResourceType, number>,
+): AvailableActionDto[] {
   const turnState = createTurnState({
     playerId: playerViewModel.player.id,
-    resources: playerViewModel.resources,
+    resources: uncommittedResources,
     actionSubmissions: [],
   })
 
@@ -392,6 +413,7 @@ export const PlayerViewDto = z.object({
   turn: z.number(),
   nextTurnAt: z.date(),
   resources: z.record(ResourceTypeSchema, z.number()),
+  uncommittedResources: z.record(ResourceTypeSchema, z.number()),
   ruleset: RulesetSchema,
   availableActions: z.array(AvailableActionDto),
 })

--- a/backend/src/api/gameplay/gameplay.repository.ts
+++ b/backend/src/api/gameplay/gameplay.repository.ts
@@ -70,7 +70,10 @@ export type PlayerViewModel = {
   readonly turn: number
   readonly nextTurnAt: Date
   readonly resources: Record<ResourceType, number>
-  readonly actionSubmissions: readonly ActionSubmission[]
+  /**
+   * All the available actions, with their targets if submitted.
+   */
+  readonly actions: readonly ActionSubmission[]
   readonly ruleset: Ruleset
 }
 
@@ -288,16 +291,9 @@ export class GameplayRepository extends PostgresRepository {
           .from(resourcesTable)
           .where(and(eq(resourcesTable.gameId, gameId), eq(resourcesTable.playerId, playerId)))
 
-        const games = await tx.select({ status: gamesTable.status }).from(gamesTable).where(eq(gamesTable.id, gameId))
-        Assert.isTrue(games.length === 1)
-        Assert.isDefined(games[0])
-
-        let currentAction: ActionSubmission | null = null
-        if (games[0].status !== GameStatus.ENDED) {
-          const currentActionResult = await this.getCurrentAction({ gameId, playerId, turn: gameState.turn }, tx)
-          rollbackOnFailure(currentActionResult, "Failed to get current action")
-          currentAction = currentActionResult.value?.actionSubmission ?? null
-        }
+        const currentActionResult = await this.getCurrentAction({ gameId, playerId, turn: gameState.turn }, tx)
+        rollbackOnFailure(currentActionResult, "Failed to get current action")
+        const currentAction = currentActionResult.value?.actionSubmission
 
         const stars = await tx.select().from(starsTable).where(eq(starsTable.gameId, gameId)).orderBy(starsTable.id)
         const planets = await tx.select().from(planetsTable).where(eq(planetsTable.gameId, gameId)).orderBy(planetsTable.id)
@@ -308,7 +304,7 @@ export class GameplayRepository extends PostgresRepository {
           opponents,
           galaxy: toGalaxyModel({ stars, planets }),
           resources: toResourceBag(playerResources),
-          actionSubmissions: currentAction === null ? [] : [currentAction],
+          actions: currentAction === undefined ? [] : [currentAction],
           ruleset: StandardRuleset, // Eventually should be stored in DB
         }
       }),

--- a/backend/src/api/gameplay/gameplay.repository.ts
+++ b/backend/src/api/gameplay/gameplay.repository.ts
@@ -22,7 +22,7 @@ import {
   starsTable,
   turnsTable,
 } from "#lib/db/schema.ts"
-import { couldNot, TransactionRollback } from "#lib/errors.ts"
+import { couldNot, rollbackOnFailure, TransactionRollback } from "#lib/errors.ts"
 import type { ActionSubmission } from "#lib/rules-engine/action-submission/ActionSubmission.ts"
 import { ResourceType } from "#lib/rules-engine/ruleset-model/mechanics/ResourceType.ts"
 import type { Ruleset } from "#lib/rules-engine/ruleset-model/Ruleset.ts"
@@ -288,8 +288,16 @@ export class GameplayRepository extends PostgresRepository {
           .from(resourcesTable)
           .where(and(eq(resourcesTable.gameId, gameId), eq(resourcesTable.playerId, playerId)))
 
-        const currentActionResult = await this.getCurrentAction({ gameId, playerId, turn: gameState.turn }, tx)
-        Assert.isSuccess(currentActionResult)
+        const games = await tx.select({ status: gamesTable.status }).from(gamesTable).where(eq(gamesTable.id, gameId))
+        Assert.isTrue(games.length === 1)
+        Assert.isDefined(games[0])
+
+        let currentAction: ActionSubmission | null = null
+        if (games[0].status !== GameStatus.ENDED) {
+          const currentActionResult = await this.getCurrentAction({ gameId, playerId, turn: gameState.turn }, tx)
+          rollbackOnFailure(currentActionResult, "Failed to get current action")
+          currentAction = currentActionResult.value?.actionSubmission ?? null
+        }
 
         const stars = await tx.select().from(starsTable).where(eq(starsTable.gameId, gameId)).orderBy(starsTable.id)
         const planets = await tx.select().from(planetsTable).where(eq(planetsTable.gameId, gameId)).orderBy(planetsTable.id)
@@ -300,7 +308,7 @@ export class GameplayRepository extends PostgresRepository {
           opponents,
           galaxy: toGalaxyModel({ stars, planets }),
           resources: toResourceBag(playerResources),
-          actionSubmissions: currentActionResult.value === null ? [] : [currentActionResult.value.actionSubmission],
+          actionSubmissions: currentAction === null ? [] : [currentAction],
           ruleset: StandardRuleset, // Eventually should be stored in DB
         }
       }),

--- a/backend/src/api/gameplay/gameplay.repository.ts
+++ b/backend/src/api/gameplay/gameplay.repository.ts
@@ -70,6 +70,7 @@ export type PlayerViewModel = {
   readonly turn: number
   readonly nextTurnAt: Date
   readonly resources: Record<ResourceType, number>
+  readonly actionSubmissions: readonly ActionSubmission[]
   readonly ruleset: Ruleset
 }
 
@@ -287,6 +288,9 @@ export class GameplayRepository extends PostgresRepository {
           .from(resourcesTable)
           .where(and(eq(resourcesTable.gameId, gameId), eq(resourcesTable.playerId, playerId)))
 
+        const currentActionResult = await this.getCurrentAction({ gameId, playerId, turn: gameState.turn }, tx)
+        Assert.isSuccess(currentActionResult)
+
         const stars = await tx.select().from(starsTable).where(eq(starsTable.gameId, gameId)).orderBy(starsTable.id)
         const planets = await tx.select().from(planetsTable).where(eq(planetsTable.gameId, gameId)).orderBy(planetsTable.id)
 
@@ -296,6 +300,7 @@ export class GameplayRepository extends PostgresRepository {
           opponents,
           galaxy: toGalaxyModel({ stars, planets }),
           resources: toResourceBag(playerResources),
+          actionSubmissions: currentActionResult.value === null ? [] : [currentActionResult.value.actionSubmission],
           ruleset: StandardRuleset, // Eventually should be stored in DB
         }
       }),

--- a/backend/src/api/gameplay/gameplay.router.test.ts
+++ b/backend/src/api/gameplay/gameplay.router.test.ts
@@ -1,6 +1,7 @@
 import { Assert, Datetime, Time, UnitOfTime } from "@guillaume-docquier/tools-ts"
 import { describe, expect, it } from "vitest"
 import { createApiStub } from "#api/createApi.stub.ts"
+import { createResourcesDtoStub } from "#api/gameplay/ResourcesDto.stub.ts"
 import { createGameConfigurationDtoStub } from "#api/lobbies/GameConfigurationDto.stub.ts"
 import { ControlledClock } from "#lib/ControlledClock.ts"
 import { createDbMock } from "#lib/db/createDb.mock.ts"
@@ -165,13 +166,11 @@ describe("gameplay.router", () => {
           date: clock.now(),
           time: Time.create(gameConfiguration.turnIntervalSeconds, UnitOfTime.SECONDS),
         }).toISOString(),
-        resources: {
+        resources: createResourcesDtoStub({
           [ResourceType.INFLUENCE]: { uncommitted: 3, total: 3 },
           [ResourceType.METAL]: { uncommitted: 2, total: 2 },
           [ResourceType.FUEL]: { uncommitted: 1, total: 1 },
-          [ResourceType.ENERGY]: { uncommitted: 0, total: 0 },
-          [ResourceType.COLONY]: { uncommitted: 0, total: 0 },
-        },
+        }),
         ruleset: StandardRuleset,
         availableActions: [
           {
@@ -231,13 +230,13 @@ describe("gameplay.router", () => {
       Assert.isDefined(generatePower)
 
       // Assert
-      expect(playerView.resources).toEqual({
-        [ResourceType.INFLUENCE]: { uncommitted: 2, total: 3 },
-        [ResourceType.METAL]: { uncommitted: 2, total: 2 },
-        [ResourceType.FUEL]: { uncommitted: 1, total: 1 },
-        [ResourceType.ENERGY]: { uncommitted: 0, total: 0 },
-        [ResourceType.COLONY]: { uncommitted: 0, total: 0 },
-      })
+      expect(playerView.resources).toEqual<typeof playerView.resources>(
+        createResourcesDtoStub({
+          [ResourceType.INFLUENCE]: { uncommitted: 2, total: 3 },
+          [ResourceType.METAL]: { uncommitted: 2, total: 2 },
+          [ResourceType.FUEL]: { uncommitted: 1, total: 1 },
+        }),
+      )
       expect(generatePower.canAfford).toBe(false)
     })
 

--- a/backend/src/api/gameplay/gameplay.router.test.ts
+++ b/backend/src/api/gameplay/gameplay.router.test.ts
@@ -171,6 +171,11 @@ describe("gameplay.router", () => {
           [ResourceType.METAL]: 2,
           [ResourceType.FUEL]: 1,
         }),
+        uncommittedResources: createResourcesStub({
+          [ResourceType.INFLUENCE]: 3,
+          [ResourceType.METAL]: 2,
+          [ResourceType.FUEL]: 1,
+        }),
         ruleset: StandardRuleset,
         availableActions: [
           {
@@ -205,6 +210,46 @@ describe("gameplay.router", () => {
           },
         ],
       })
+    })
+
+    it("should expose uncommitted resources and use them to determine Action affordability", async () => {
+      // Arrange
+      using apiServer = new ApiServer(await createApiStub())
+      const player = await apiServer.createClient({ authenticated: true })
+      const { createdGameId } = await player.client.lobbies.create.mutate({ configuration: createGameConfigurationDtoStub() })
+      await player.client.gameplay.startGame.mutate({ gameId: createdGameId })
+
+      const initialPlayerView = await player.client.gameplay.getPlayerView.query({ gameId: createdGameId })
+      const extractMetal = initialPlayerView.availableActions.find(({ actionDefinitionId }) => actionDefinitionId === GainMetal.id)
+      Assert.isDefined(extractMetal)
+
+      await player.client.gameplay.setCurrentAction.mutate({
+        gameId: createdGameId,
+        turn: initialPlayerView.turn,
+        actionSubmission: extractMetal,
+      })
+
+      // Act
+      const playerView = await player.client.gameplay.getPlayerView.query({ gameId: createdGameId })
+      const generatePower = playerView.availableActions.find(({ actionDefinitionId }) => actionDefinitionId === GainEnergy.id)
+      Assert.isDefined(generatePower)
+
+      // Assert
+      expect(playerView.resources).toEqual(
+        createResourcesStub({
+          [ResourceType.INFLUENCE]: 3,
+          [ResourceType.METAL]: 2,
+          [ResourceType.FUEL]: 1,
+        }),
+      )
+      expect(playerView.uncommittedResources).toEqual(
+        createResourcesStub({
+          [ResourceType.INFLUENCE]: 2,
+          [ResourceType.METAL]: 2,
+          [ResourceType.FUEL]: 1,
+        }),
+      )
+      expect(generatePower.canAfford).toBe(false)
     })
 
     it("should expose the current player and every opponent with their colors", async () => {

--- a/backend/src/api/gameplay/gameplay.router.test.ts
+++ b/backend/src/api/gameplay/gameplay.router.test.ts
@@ -8,7 +8,6 @@ import { PlanetBiome } from "#lib/db/gameplay/PlanetBiome.ts"
 import { PlanetSize } from "#lib/db/gameplay/PlanetSize.ts"
 import { PlayerColor } from "#lib/db/PlayerColor.ts"
 import { createActionSubmissionStub } from "#lib/rules-engine/action-submission/ActionSubmission.stub.ts"
-import { createResourcesStub } from "#lib/rules-engine/ruleset-model/mechanics/Resources.stub.ts"
 import { ResourceType } from "#lib/rules-engine/ruleset-model/mechanics/ResourceType.ts"
 import { GainEnergy } from "#lib/rulesets/standard/action-definitions/gain-energy.ts"
 import { GainFuel } from "#lib/rulesets/standard/action-definitions/gain-fuel.ts"
@@ -166,16 +165,13 @@ describe("gameplay.router", () => {
           date: clock.now(),
           time: Time.create(gameConfiguration.turnIntervalSeconds, UnitOfTime.SECONDS),
         }).toISOString(),
-        resources: createResourcesStub({
-          [ResourceType.INFLUENCE]: 3,
-          [ResourceType.METAL]: 2,
-          [ResourceType.FUEL]: 1,
-        }),
-        uncommittedResources: createResourcesStub({
-          [ResourceType.INFLUENCE]: 3,
-          [ResourceType.METAL]: 2,
-          [ResourceType.FUEL]: 1,
-        }),
+        resources: {
+          [ResourceType.INFLUENCE]: { uncommitted: 3, total: 3 },
+          [ResourceType.METAL]: { uncommitted: 2, total: 2 },
+          [ResourceType.FUEL]: { uncommitted: 1, total: 1 },
+          [ResourceType.ENERGY]: { uncommitted: 0, total: 0 },
+          [ResourceType.COLONY]: { uncommitted: 0, total: 0 },
+        },
         ruleset: StandardRuleset,
         availableActions: [
           {
@@ -235,20 +231,13 @@ describe("gameplay.router", () => {
       Assert.isDefined(generatePower)
 
       // Assert
-      expect(playerView.resources).toEqual(
-        createResourcesStub({
-          [ResourceType.INFLUENCE]: 3,
-          [ResourceType.METAL]: 2,
-          [ResourceType.FUEL]: 1,
-        }),
-      )
-      expect(playerView.uncommittedResources).toEqual(
-        createResourcesStub({
-          [ResourceType.INFLUENCE]: 2,
-          [ResourceType.METAL]: 2,
-          [ResourceType.FUEL]: 1,
-        }),
-      )
+      expect(playerView.resources).toEqual({
+        [ResourceType.INFLUENCE]: { uncommitted: 2, total: 3 },
+        [ResourceType.METAL]: { uncommitted: 2, total: 2 },
+        [ResourceType.FUEL]: { uncommitted: 1, total: 1 },
+        [ResourceType.ENERGY]: { uncommitted: 0, total: 0 },
+        [ResourceType.COLONY]: { uncommitted: 0, total: 0 },
+      })
       expect(generatePower.canAfford).toBe(false)
     })
 

--- a/backend/src/api/lobbies/lobbies.concurrency.test.ts
+++ b/backend/src/api/lobbies/lobbies.concurrency.test.ts
@@ -1,5 +1,6 @@
 import { Assert, Result } from "@guillaume-docquier/tools-ts"
 import { describe, expect, it } from "vitest"
+import { createResourcesDtoStub } from "#api/gameplay/ResourcesDto.stub.ts"
 import { createGameConfigurationDtoStub } from "#api/lobbies/GameConfigurationDto.stub.ts"
 import { MAX_NB_SEATS } from "#api/lobbies/lobbies.controller.ts"
 import { ResourceType } from "#lib/rules-engine/ruleset-model/mechanics/ResourceType.ts"
@@ -69,13 +70,13 @@ describe("lobby concurrency", () => {
     for (const gameParticipant of gameParticipants) {
       Assert.isDefined(gameParticipant)
       const playerView = await gameParticipant.client.gameplay.getPlayerView.query({ gameId: createdGameId })
-      expect(playerView.resources).toEqual({
-        [ResourceType.INFLUENCE]: { uncommitted: 3, total: 3 },
-        [ResourceType.METAL]: { uncommitted: 2, total: 2 },
-        [ResourceType.FUEL]: { uncommitted: 1, total: 1 },
-        [ResourceType.ENERGY]: { uncommitted: 0, total: 0 },
-        [ResourceType.COLONY]: { uncommitted: 0, total: 0 },
-      })
+      expect(playerView.resources).toEqual<typeof playerView.resources>(
+        createResourcesDtoStub({
+          [ResourceType.INFLUENCE]: { uncommitted: 3, total: 3 },
+          [ResourceType.METAL]: { uncommitted: 2, total: 2 },
+          [ResourceType.FUEL]: { uncommitted: 1, total: 1 },
+        }),
+      )
     }
   })
 })

--- a/backend/src/api/lobbies/lobbies.concurrency.test.ts
+++ b/backend/src/api/lobbies/lobbies.concurrency.test.ts
@@ -2,7 +2,6 @@ import { Assert, Result } from "@guillaume-docquier/tools-ts"
 import { describe, expect, it } from "vitest"
 import { createGameConfigurationDtoStub } from "#api/lobbies/GameConfigurationDto.stub.ts"
 import { MAX_NB_SEATS } from "#api/lobbies/lobbies.controller.ts"
-import { createResourcesStub } from "#lib/rules-engine/ruleset-model/mechanics/Resources.stub.ts"
 import { ResourceType } from "#lib/rules-engine/ruleset-model/mechanics/ResourceType.ts"
 import { ConcurrencyTestApiServer } from "#tests/ConcurrencyTestApiServer.ts"
 
@@ -70,13 +69,13 @@ describe("lobby concurrency", () => {
     for (const gameParticipant of gameParticipants) {
       Assert.isDefined(gameParticipant)
       const playerView = await gameParticipant.client.gameplay.getPlayerView.query({ gameId: createdGameId })
-      expect(playerView.resources).toEqual(
-        createResourcesStub({
-          [ResourceType.INFLUENCE]: 3,
-          [ResourceType.METAL]: 2,
-          [ResourceType.FUEL]: 1,
-        }),
-      )
+      expect(playerView.resources).toEqual({
+        [ResourceType.INFLUENCE]: { uncommitted: 3, total: 3 },
+        [ResourceType.METAL]: { uncommitted: 2, total: 2 },
+        [ResourceType.FUEL]: { uncommitted: 1, total: 1 },
+        [ResourceType.ENERGY]: { uncommitted: 0, total: 0 },
+        [ResourceType.COLONY]: { uncommitted: 0, total: 0 },
+      })
     }
   })
 })

--- a/backend/src/turn-processing/TurnProcessor.test.ts
+++ b/backend/src/turn-processing/TurnProcessor.test.ts
@@ -4,7 +4,6 @@ import { createApiStub } from "#api/createApi.stub.ts"
 import { createGameConfigurationDtoStub } from "#api/lobbies/GameConfigurationDto.stub.ts"
 import { ControlledClock } from "#lib/ControlledClock.ts"
 import { createDbMock } from "#lib/db/createDb.mock.ts"
-import { createResourcesStub } from "#lib/rules-engine/ruleset-model/mechanics/Resources.stub.ts"
 import { ResourceType } from "#lib/rules-engine/ruleset-model/mechanics/ResourceType.ts"
 import { GainInfluence } from "#lib/rulesets/standard/action-definitions/gain-influence.ts"
 import { GainMetal } from "#lib/rulesets/standard/action-definitions/gain-metal.ts"
@@ -53,12 +52,12 @@ describe("TurnProcessor", () => {
 
       expect(await player.client.gameplay.getPlayerView.query({ gameId: firstGameId })).toMatchObject({
         turn: 1,
-        resources: { [ResourceType.INFLUENCE]: 3 },
+        resources: { [ResourceType.INFLUENCE]: { total: 3 } },
       })
 
       expect(await player.client.gameplay.getPlayerView.query({ gameId: secondGameId })).toMatchObject({
         turn: 1,
-        resources: { [ResourceType.INFLUENCE]: 3 },
+        resources: { [ResourceType.INFLUENCE]: { total: 3 } },
       })
     })
 
@@ -97,12 +96,12 @@ describe("TurnProcessor", () => {
       // No turns were processed because turns in error block, this will be resolved by https://github.com/Guillaume-Docquier/text-based-browser-game-1/issues/278
       expect(await player.client.gameplay.getPlayerView.query({ gameId: failingGameId })).toMatchObject({
         turn: 0,
-        resources: { [ResourceType.INFLUENCE]: 3 },
+        resources: { [ResourceType.INFLUENCE]: { total: 3 } },
       })
 
       expect(await player.client.gameplay.getPlayerView.query({ gameId: successfulGameId })).toMatchObject({
         turn: 0,
-        resources: { [ResourceType.INFLUENCE]: 3 },
+        resources: { [ResourceType.INFLUENCE]: { total: 3 } },
       })
     })
   })
@@ -141,16 +140,13 @@ describe("TurnProcessor", () => {
         ...initialPlayerView,
         turn: 1,
         nextTurnAt: Datetime.increment({ date: clock.now(), time: turnInterval }).toISOString(),
-        resources: createResourcesStub({
-          [ResourceType.INFLUENCE]: 8,
-          [ResourceType.METAL]: 2,
-          [ResourceType.FUEL]: 1,
-        }),
-        uncommittedResources: createResourcesStub({
-          [ResourceType.INFLUENCE]: 8,
-          [ResourceType.METAL]: 2,
-          [ResourceType.FUEL]: 1,
-        }),
+        resources: {
+          [ResourceType.INFLUENCE]: { uncommitted: 8, total: 8 },
+          [ResourceType.METAL]: { uncommitted: 2, total: 2 },
+          [ResourceType.FUEL]: { uncommitted: 1, total: 1 },
+          [ResourceType.ENERGY]: { uncommitted: 0, total: 0 },
+          [ResourceType.COLONY]: { uncommitted: 0, total: 0 },
+        },
         availableActions: expect.any(Array),
       })
     })
@@ -219,13 +215,6 @@ describe("TurnProcessor", () => {
       const result = await turnProcessor.processNextDueTurn()
 
       // Assert
-      const playerView = await player.client.gameplay.getPlayerView.query({ gameId: createdGameId })
-      expect(playerView).toMatchObject({
-        turn: 0,
-        resources: {
-          [ResourceType.INFLUENCE]: 0,
-        },
-      })
       expect(result).toBe("failed")
     })
 
@@ -259,12 +248,12 @@ describe("TurnProcessor", () => {
       // Assert
       expect(await player.client.gameplay.getPlayerView.query({ gameId: laterGameId })).toMatchObject({
         turn: 0,
-        resources: { [ResourceType.INFLUENCE]: 3 },
+        resources: { [ResourceType.INFLUENCE]: { total: 3 } },
       })
 
       expect(await player.client.gameplay.getPlayerView.query({ gameId: earlierGameId })).toMatchObject({
         turn: 1,
-        resources: { [ResourceType.INFLUENCE]: 3 },
+        resources: { [ResourceType.INFLUENCE]: { total: 3 } },
       })
     })
 
@@ -293,7 +282,7 @@ describe("TurnProcessor", () => {
       // Assert
       expect(await player.client.gameplay.getPlayerView.query({ gameId })).toMatchObject({
         turn: 2,
-        resources: { [ResourceType.INFLUENCE]: 3 },
+        resources: { [ResourceType.INFLUENCE]: { total: 3 } },
       })
     })
 
@@ -320,7 +309,7 @@ describe("TurnProcessor", () => {
       expect(processingResults).toEqual<typeof processingResults>(["processed", "idle"])
       expect(await player.client.gameplay.getPlayerView.query({ gameId: processingGameId })).toMatchObject({
         turn: 1,
-        resources: { [ResourceType.INFLUENCE]: 3 },
+        resources: { [ResourceType.INFLUENCE]: { total: 3 } },
       })
     })
 
@@ -354,12 +343,12 @@ describe("TurnProcessor", () => {
       // Assert
       expect(await player.client.gameplay.getPlayerView.query({ gameId: failingGameId })).toMatchObject({
         turn: 0,
-        resources: { [ResourceType.INFLUENCE]: 3 },
+        resources: { [ResourceType.INFLUENCE]: { total: 3 } },
       })
 
       expect(await player.client.gameplay.getPlayerView.query({ gameId: successfulGameId })).toMatchObject({
         turn: 0,
-        resources: { [ResourceType.INFLUENCE]: 3 },
+        resources: { [ResourceType.INFLUENCE]: { total: 3 } },
       })
     })
 
@@ -393,12 +382,12 @@ describe("TurnProcessor", () => {
       // Assert
       expect(await player.client.gameplay.getPlayerView.query({ gameId: earlierGameId })).toMatchObject({
         turn: 1,
-        resources: { [ResourceType.INFLUENCE]: 3 },
+        resources: { [ResourceType.INFLUENCE]: { total: 3 } },
       })
 
       expect(await player.client.gameplay.getPlayerView.query({ gameId: laterGameId })).toMatchObject({
         turn: 1,
-        resources: { [ResourceType.INFLUENCE]: 3 },
+        resources: { [ResourceType.INFLUENCE]: { total: 3 } },
       })
     })
 
@@ -425,7 +414,7 @@ describe("TurnProcessor", () => {
       // Assert
       expect(await player.client.gameplay.getPlayerView.query({ gameId })).toMatchObject({
         turn: 1,
-        resources: { [ResourceType.INFLUENCE]: 3 },
+        resources: { [ResourceType.INFLUENCE]: { total: 3 } },
       })
     })
 
@@ -484,14 +473,14 @@ describe("TurnProcessor", () => {
       const creatorView = await creator.client.gameplay.getPlayerView.query({ gameId: createdGameId })
       expect(creatorView).toMatchObject({
         resources: {
-          [ResourceType.INFLUENCE]: 3,
+          [ResourceType.INFLUENCE]: { total: 3 },
         },
       })
 
       const joinerView = await joiner.client.gameplay.getPlayerView.query({ gameId: createdGameId })
       expect(joinerView).toMatchObject({
         resources: {
-          [ResourceType.INFLUENCE]: 5,
+          [ResourceType.INFLUENCE]: { total: 5 },
         },
       })
     })
@@ -533,14 +522,14 @@ describe("TurnProcessor", () => {
       expect(playerViewAfterFailedSave).toMatchObject({
         turn: 0,
         resources: {
-          [ResourceType.INFLUENCE]: 3,
+          [ResourceType.INFLUENCE]: { total: 3 },
         },
       })
       expect(retriedProcessingResult).toBe("processed")
       expect(playerViewAfterRetry).toMatchObject({
         turn: 1,
         resources: {
-          [ResourceType.INFLUENCE]: 8,
+          [ResourceType.INFLUENCE]: { total: 8 },
         },
       })
     })

--- a/backend/src/turn-processing/TurnProcessor.test.ts
+++ b/backend/src/turn-processing/TurnProcessor.test.ts
@@ -1,6 +1,7 @@
 import { Assert, Datetime, Result, Time, UnitOfTime } from "@guillaume-docquier/tools-ts"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { createApiStub } from "#api/createApi.stub.ts"
+import { createResourcesDtoStub } from "#api/gameplay/ResourcesDto.stub.ts"
 import { createGameConfigurationDtoStub } from "#api/lobbies/GameConfigurationDto.stub.ts"
 import { ControlledClock } from "#lib/ControlledClock.ts"
 import { createDbMock } from "#lib/db/createDb.mock.ts"
@@ -52,12 +53,12 @@ describe("TurnProcessor", () => {
 
       expect(await player.client.gameplay.getPlayerView.query({ gameId: firstGameId })).toMatchObject({
         turn: 1,
-        resources: { [ResourceType.INFLUENCE]: { total: 3 } },
+        resources: { [ResourceType.INFLUENCE]: { total: 3, uncommitted: 3 } },
       })
 
       expect(await player.client.gameplay.getPlayerView.query({ gameId: secondGameId })).toMatchObject({
         turn: 1,
-        resources: { [ResourceType.INFLUENCE]: { total: 3 } },
+        resources: { [ResourceType.INFLUENCE]: { total: 3, uncommitted: 3 } },
       })
     })
 
@@ -96,12 +97,12 @@ describe("TurnProcessor", () => {
       // No turns were processed because turns in error block, this will be resolved by https://github.com/Guillaume-Docquier/text-based-browser-game-1/issues/278
       expect(await player.client.gameplay.getPlayerView.query({ gameId: failingGameId })).toMatchObject({
         turn: 0,
-        resources: { [ResourceType.INFLUENCE]: { total: 3 } },
+        resources: { [ResourceType.INFLUENCE]: { total: 3, uncommitted: 3 } },
       })
 
       expect(await player.client.gameplay.getPlayerView.query({ gameId: successfulGameId })).toMatchObject({
         turn: 0,
-        resources: { [ResourceType.INFLUENCE]: { total: 3 } },
+        resources: { [ResourceType.INFLUENCE]: { total: 3, uncommitted: 3 } },
       })
     })
   })
@@ -140,13 +141,11 @@ describe("TurnProcessor", () => {
         ...initialPlayerView,
         turn: 1,
         nextTurnAt: Datetime.increment({ date: clock.now(), time: turnInterval }).toISOString(),
-        resources: {
+        resources: createResourcesDtoStub({
           [ResourceType.INFLUENCE]: { uncommitted: 8, total: 8 },
           [ResourceType.METAL]: { uncommitted: 2, total: 2 },
           [ResourceType.FUEL]: { uncommitted: 1, total: 1 },
-          [ResourceType.ENERGY]: { uncommitted: 0, total: 0 },
-          [ResourceType.COLONY]: { uncommitted: 0, total: 0 },
-        },
+        }),
         availableActions: expect.any(Array),
       })
     })
@@ -248,12 +247,12 @@ describe("TurnProcessor", () => {
       // Assert
       expect(await player.client.gameplay.getPlayerView.query({ gameId: laterGameId })).toMatchObject({
         turn: 0,
-        resources: { [ResourceType.INFLUENCE]: { total: 3 } },
+        resources: { [ResourceType.INFLUENCE]: { total: 3, uncommitted: 3 } },
       })
 
       expect(await player.client.gameplay.getPlayerView.query({ gameId: earlierGameId })).toMatchObject({
         turn: 1,
-        resources: { [ResourceType.INFLUENCE]: { total: 3 } },
+        resources: { [ResourceType.INFLUENCE]: { total: 3, uncommitted: 3 } },
       })
     })
 
@@ -282,7 +281,7 @@ describe("TurnProcessor", () => {
       // Assert
       expect(await player.client.gameplay.getPlayerView.query({ gameId })).toMatchObject({
         turn: 2,
-        resources: { [ResourceType.INFLUENCE]: { total: 3 } },
+        resources: { [ResourceType.INFLUENCE]: { total: 3, uncommitted: 3 } },
       })
     })
 
@@ -309,7 +308,7 @@ describe("TurnProcessor", () => {
       expect(processingResults).toEqual<typeof processingResults>(["processed", "idle"])
       expect(await player.client.gameplay.getPlayerView.query({ gameId: processingGameId })).toMatchObject({
         turn: 1,
-        resources: { [ResourceType.INFLUENCE]: { total: 3 } },
+        resources: { [ResourceType.INFLUENCE]: { total: 3, uncommitted: 3 } },
       })
     })
 
@@ -343,12 +342,12 @@ describe("TurnProcessor", () => {
       // Assert
       expect(await player.client.gameplay.getPlayerView.query({ gameId: failingGameId })).toMatchObject({
         turn: 0,
-        resources: { [ResourceType.INFLUENCE]: { total: 3 } },
+        resources: { [ResourceType.INFLUENCE]: { total: 3, uncommitted: 3 } },
       })
 
       expect(await player.client.gameplay.getPlayerView.query({ gameId: successfulGameId })).toMatchObject({
         turn: 0,
-        resources: { [ResourceType.INFLUENCE]: { total: 3 } },
+        resources: { [ResourceType.INFLUENCE]: { total: 3, uncommitted: 3 } },
       })
     })
 
@@ -382,12 +381,12 @@ describe("TurnProcessor", () => {
       // Assert
       expect(await player.client.gameplay.getPlayerView.query({ gameId: earlierGameId })).toMatchObject({
         turn: 1,
-        resources: { [ResourceType.INFLUENCE]: { total: 3 } },
+        resources: { [ResourceType.INFLUENCE]: { total: 3, uncommitted: 3 } },
       })
 
       expect(await player.client.gameplay.getPlayerView.query({ gameId: laterGameId })).toMatchObject({
         turn: 1,
-        resources: { [ResourceType.INFLUENCE]: { total: 3 } },
+        resources: { [ResourceType.INFLUENCE]: { total: 3, uncommitted: 3 } },
       })
     })
 
@@ -414,7 +413,7 @@ describe("TurnProcessor", () => {
       // Assert
       expect(await player.client.gameplay.getPlayerView.query({ gameId })).toMatchObject({
         turn: 1,
-        resources: { [ResourceType.INFLUENCE]: { total: 3 } },
+        resources: { [ResourceType.INFLUENCE]: { total: 3, uncommitted: 3 } },
       })
     })
 
@@ -472,15 +471,17 @@ describe("TurnProcessor", () => {
 
       const creatorView = await creator.client.gameplay.getPlayerView.query({ gameId: createdGameId })
       expect(creatorView).toMatchObject({
+        turn: 1,
         resources: {
-          [ResourceType.INFLUENCE]: { total: 3 },
+          [ResourceType.INFLUENCE]: { total: 3, uncommitted: 3 },
         },
       })
 
       const joinerView = await joiner.client.gameplay.getPlayerView.query({ gameId: createdGameId })
       expect(joinerView).toMatchObject({
+        turn: 1,
         resources: {
-          [ResourceType.INFLUENCE]: { total: 5 },
+          [ResourceType.INFLUENCE]: { total: 5, uncommitted: 5 },
         },
       })
     })
@@ -522,14 +523,14 @@ describe("TurnProcessor", () => {
       expect(playerViewAfterFailedSave).toMatchObject({
         turn: 0,
         resources: {
-          [ResourceType.INFLUENCE]: { total: 3 },
+          [ResourceType.INFLUENCE]: { total: 3, uncommitted: 3 },
         },
       })
       expect(retriedProcessingResult).toBe("processed")
       expect(playerViewAfterRetry).toMatchObject({
         turn: 1,
         resources: {
-          [ResourceType.INFLUENCE]: { total: 8 },
+          [ResourceType.INFLUENCE]: { total: 8, uncommitted: 8 },
         },
       })
     })

--- a/backend/src/turn-processing/TurnProcessor.test.ts
+++ b/backend/src/turn-processing/TurnProcessor.test.ts
@@ -146,6 +146,11 @@ describe("TurnProcessor", () => {
           [ResourceType.METAL]: 2,
           [ResourceType.FUEL]: 1,
         }),
+        uncommittedResources: createResourcesStub({
+          [ResourceType.INFLUENCE]: 8,
+          [ResourceType.METAL]: 2,
+          [ResourceType.FUEL]: 1,
+        }),
         availableActions: expect.any(Array),
       })
     })

--- a/backend/src/turn-processing/TurnProcessor.ts
+++ b/backend/src/turn-processing/TurnProcessor.ts
@@ -141,6 +141,7 @@ export class TurnProcessor {
     const turnResult: Omit<ProcessedTurnModel, "gameStatus"> = {
       gameId: turnToProcess.gameId,
       turn: turnToProcess.turn,
+      nextTurn: turnToProcess.turn + 1,
       processedAt,
       rngState: rng.getState(),
       playerResources: Object.values(resolvedTurnResult.value.players).flatMap((player) =>
@@ -156,14 +157,11 @@ export class TurnProcessor {
       return Result.Success({
         ...turnResult,
         gameStatus: GameStatus.COLLECTING_ACTIONS,
-        nextTurn: {
-          turn: turnToProcess.turn + 1,
-          scheduledFor: getNextTurnScheduledFor({
-            scheduledFor: turnToProcess.scheduledFor,
-            processedAt,
-            turnInterval: turnToProcess.turnInterval,
-          }),
-        },
+        nextTurnScheduledFor: getNextTurnScheduledFor({
+          scheduledFor: turnToProcess.scheduledFor,
+          processedAt,
+          turnInterval: turnToProcess.turnInterval,
+        }),
       })
     }
 

--- a/backend/src/turn-processing/turns.repository.ts
+++ b/backend/src/turn-processing/turns.repository.ts
@@ -66,13 +66,17 @@ export type ProcessedTurnModel = {
     resourceType: ResourceType
     amount: number
   }>
-  gameStatus: GameStatus
+  gameStatus: GameStatus // We could discriminate on gameStatus, but in the current shape of things it makes the code a lot more complicated
   winnerAccountId?: AccountId
+  nextTurn: number
+  /**
+   * Not defined when endedAt is set
+   */
+  nextTurnScheduledFor?: Date
+  /**
+   * Not defined when nextTurnScheduledFor is set
+   */
   endedAt?: Date
-  nextTurn?: {
-    turn: number
-    scheduledFor: Date
-  }
 }
 
 export class TurnsRepository extends PostgresRepository {
@@ -281,29 +285,29 @@ export class TurnsRepository extends PostgresRepository {
             },
           })
 
-        if (processedTurnModel.nextTurn !== undefined) {
+        if (processedTurnModel.nextTurnScheduledFor !== undefined) {
           const insertedTurns = await tx
             .insert(turnsTable)
             .values({
               gameId: processedTurnModel.gameId,
-              turn: processedTurnModel.nextTurn.turn,
-              scheduledFor: processedTurnModel.nextTurn.scheduledFor,
+              turn: processedTurnModel.nextTurn,
+              scheduledFor: processedTurnModel.nextTurnScheduledFor,
             })
             .returning()
           Assert.isTrue(insertedTurns.length === 1)
-
-          const updatedGameStates = await tx
-            .update(gameStatesTable)
-            .set({
-              turn: processedTurnModel.nextTurn.turn,
-              nextTurnAt: processedTurnModel.nextTurn.scheduledFor,
-              rngGeneratorState: processedTurnModel.rngState.generatorState,
-              rngSpareNormal: processedTurnModel.rngState.spareNormal,
-            })
-            .where(and(eq(gameStatesTable.gameId, processedTurnModel.gameId), eq(gameStatesTable.turn, processedTurnModel.turn)))
-            .returning()
-          Assert.isTrue(updatedGameStates.length === 1)
         }
+
+        const updatedGameStates = await tx
+          .update(gameStatesTable)
+          .set({
+            turn: processedTurnModel.nextTurn,
+            nextTurnAt: processedTurnModel.nextTurnScheduledFor,
+            rngGeneratorState: processedTurnModel.rngState.generatorState,
+            rngSpareNormal: processedTurnModel.rngState.spareNormal,
+          })
+          .where(and(eq(gameStatesTable.gameId, processedTurnModel.gameId), eq(gameStatesTable.turn, processedTurnModel.turn)))
+          .returning()
+        Assert.isTrue(updatedGameStates.length === 1)
       }),
     )
 

--- a/docs/game-design/systems/014-resources.md
+++ b/docs/game-design/systems/014-resources.md
@@ -51,7 +51,7 @@ Relates to:
 
 ## Current Implementation
 
-Each player currently has integer stockpiles for all five Resources and starts with placeholder amounts. Standard Ruleset Actions can gain Influence, Metal, Fuel, and Energy and spend those Resources as configured costs. Colony is stored and displayed but has no current source or use. The frontend displays the stockpiles, Action costs, and affordability.
+Each player currently has integer stockpiles for all five Resources and starts with placeholder amounts. Standard Ruleset Actions can gain Influence, Metal, Fuel, and Energy and spend those Resources as configured costs. Colony is stored and displayed but has no current source or use. The player view exposes both total and uncommitted Resources, and the frontend displays them with Action costs and affordability.
 
 ## Rules
 

--- a/frontend/playwright/specs/lobbies.spec.ts
+++ b/frontend/playwright/specs/lobbies.spec.ts
@@ -68,7 +68,16 @@ test.describe("authenticated user", () => {
         (await topBarResources.all()).map(async (resource) => await resource.getAttribute("aria-label")),
       )
 
-      expect(resourceLabels).toEqual(["3 Influence", "2 Metal", "0 Energy", "1 Fuel", "0 Colony"])
+      expect(resourceLabels).toEqual([
+        "3 available of 3 Influence",
+        "2 available of 2 Metal",
+        "0 available of 0 Energy",
+        "1 available of 1 Fuel",
+        "0 available of 0 Colony",
+      ])
+
+      await topBarResources.first().hover()
+      await expect(galaxyPage.gameTopBar.getByText("3 available of 3", { exact: true })).toBeVisible()
     })
 
     await test.step("Center and fit a Galaxy region", async () => {
@@ -178,9 +187,12 @@ test.describe("authenticated user", () => {
 
       await extractMetal.click()
       await expect(extractMetal).toHaveAttribute("aria-pressed", "true")
+      await expect(actionsPage.resources.first()).toHaveAttribute("aria-label", "2 available of 3 Influence")
+      await expect(actionsPage.action("Generate Power")).toHaveAttribute("aria-disabled", "true")
 
       await extractMetal.click()
       await expect(extractMetal).toHaveAttribute("aria-pressed", "false")
+      await expect(actionsPage.resources.first()).toHaveAttribute("aria-label", "3 available of 3 Influence")
     })
 
     await test.step("Display Action costs in their canonical order", async () => {

--- a/frontend/src/features/play/components/ActionCard.tsx
+++ b/frontend/src/features/play/components/ActionCard.tsx
@@ -45,14 +45,14 @@ const ACTION_TYPE_ICONS = {
  */
 export function ActionCard({
   actionDefinition,
-  uncommittedResources,
+  resources,
   canAfford,
   isSelected,
   disabled,
   onSelect,
 }: {
   actionDefinition: ActionDefinition
-  uncommittedResources: PlayerView["uncommittedResources"]
+  resources: PlayerView["resources"]
   canAfford: boolean
   isSelected: boolean
   disabled: boolean
@@ -112,7 +112,7 @@ export function ActionCard({
               {formatRulesetTerm(actionDefinition.tier)} {formatRulesetTerm(actionDefinition.type)}
             </CardDescription>
           </div>
-          <ActionCosts costs={actionDefinition.costs} uncommittedResources={uncommittedResources} />
+          <ActionCosts costs={actionDefinition.costs} resources={resources} />
         </div>
       </CardHeader>
       <CardContent className="relative z-10 flex min-h-36 flex-1 flex-col gap-4 border-t border-border/70 px-5 py-5">
@@ -124,20 +124,14 @@ export function ActionCard({
   )
 }
 
-function ActionCosts({
-  costs,
-  uncommittedResources,
-}: {
-  costs: ActionDefinition["costs"]
-  uncommittedResources: PlayerView["uncommittedResources"]
-}): ReactElement {
+function ActionCosts({ costs, resources }: { costs: ActionDefinition["costs"]; resources: PlayerView["resources"] }): ReactElement {
   const costsByResource = Map.groupBy(sortResources(costs), ({ resourceType }) => resourceType)
 
   return (
     <div className="flex flex-col items-end gap-1" aria-label="Costs">
       {[...costsByResource].map(([resourceType, resourceCosts]) => {
         const quantity = resourceCosts.reduce((total, cost) => total + cost.quantity, 0)
-        const cannotAfford = quantity > uncommittedResources[resourceType]
+        const cannotAfford = quantity > resources[resourceType].uncommitted
         const ResourceIcon = RESOURCE_ICONS[resourceType]
         return (
           <div

--- a/frontend/src/features/play/components/ActionCard.tsx
+++ b/frontend/src/features/play/components/ActionCard.tsx
@@ -45,14 +45,14 @@ const ACTION_TYPE_ICONS = {
  */
 export function ActionCard({
   actionDefinition,
-  resources,
+  uncommittedResources,
   canAfford,
   isSelected,
   disabled,
   onSelect,
 }: {
   actionDefinition: ActionDefinition
-  resources: PlayerView["resources"]
+  uncommittedResources: PlayerView["uncommittedResources"]
   canAfford: boolean
   isSelected: boolean
   disabled: boolean
@@ -112,7 +112,7 @@ export function ActionCard({
               {formatRulesetTerm(actionDefinition.tier)} {formatRulesetTerm(actionDefinition.type)}
             </CardDescription>
           </div>
-          <ActionCosts costs={actionDefinition.costs} resources={resources} />
+          <ActionCosts costs={actionDefinition.costs} uncommittedResources={uncommittedResources} />
         </div>
       </CardHeader>
       <CardContent className="relative z-10 flex min-h-36 flex-1 flex-col gap-4 border-t border-border/70 px-5 py-5">
@@ -124,14 +124,20 @@ export function ActionCard({
   )
 }
 
-function ActionCosts({ costs, resources }: { costs: ActionDefinition["costs"]; resources: PlayerView["resources"] }): ReactElement {
+function ActionCosts({
+  costs,
+  uncommittedResources,
+}: {
+  costs: ActionDefinition["costs"]
+  uncommittedResources: PlayerView["uncommittedResources"]
+}): ReactElement {
   const costsByResource = Map.groupBy(sortResources(costs), ({ resourceType }) => resourceType)
 
   return (
     <div className="flex flex-col items-end gap-1" aria-label="Costs">
       {[...costsByResource].map(([resourceType, resourceCosts]) => {
         const quantity = resourceCosts.reduce((total, cost) => total + cost.quantity, 0)
-        const cannotAfford = quantity > resources[resourceType]
+        const cannotAfford = quantity > uncommittedResources[resourceType]
         const ResourceIcon = RESOURCE_ICONS[resourceType]
         return (
           <div

--- a/frontend/src/features/play/components/ActionSelector.tsx
+++ b/frontend/src/features/play/components/ActionSelector.tsx
@@ -54,7 +54,7 @@ export function ActionSelector({
               <ActionCard
                 key={action.id}
                 actionDefinition={definition}
-                resources={playerView.resources}
+                uncommittedResources={playerView.uncommittedResources}
                 canAfford={action.canAfford}
                 isSelected={isSelected}
                 disabled={setCurrentAction.isPending || (!action.canAfford && !isSelected)}

--- a/frontend/src/features/play/components/ActionSelector.tsx
+++ b/frontend/src/features/play/components/ActionSelector.tsx
@@ -54,7 +54,7 @@ export function ActionSelector({
               <ActionCard
                 key={action.id}
                 actionDefinition={definition}
-                uncommittedResources={playerView.uncommittedResources}
+                resources={playerView.resources}
                 canAfford={action.canAfford}
                 isSelected={isSelected}
                 disabled={setCurrentAction.isPending || (!action.canAfford && !isSelected)}

--- a/frontend/src/features/play/components/GameTopBar.tsx
+++ b/frontend/src/features/play/components/GameTopBar.tsx
@@ -22,7 +22,7 @@ export function GameTopBar({ game, playerView }: { game: Lobby; playerView: Play
         </div>
         <div className="flex flex-wrap gap-2">
           <PlayerFact game={game} player={playerView.player} />
-          <ResourcesFact resources={playerView.resources} />
+          <ResourcesFact resources={playerView.resources} uncommittedResources={playerView.uncommittedResources} />
           <TurnFact turn={playerView.turn} />
           <NextTurnFact targetTimestamp={playerView.nextTurnAt} />
         </div>
@@ -57,10 +57,22 @@ function TurnFact({ turn }: { turn: PlayerView["turn"] }): ReactElement {
   return <TopBarFact icon={<TimerReset className="size-4" />} label="Turn" value={turn.toString()} />
 }
 
-function ResourcesFact({ resources }: { resources: PlayerView["resources"] }): ReactElement {
+function ResourcesFact({
+  resources,
+  uncommittedResources,
+}: {
+  resources: PlayerView["resources"]
+  uncommittedResources: PlayerView["uncommittedResources"]
+}): ReactElement {
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Object.entries preserves the keys of the typed resource record at runtime.
   const resourceEntries = Object.entries(resources) as Array<[keyof typeof resources, number]>
-  const sortedResources = sortResources(resourceEntries.map(([resourceType, quantity]) => ({ resourceType, quantity })))
+  const sortedResources = sortResources(
+    resourceEntries.map(([resourceType, quantity]) => ({
+      resourceType,
+      quantity,
+      uncommittedQuantity: uncommittedResources[resourceType],
+    })),
+  )
 
   return (
     <div className="group/resources relative">
@@ -68,13 +80,19 @@ function ResourcesFact({ resources }: { resources: PlayerView["resources"] }): R
         <div>
           <div className="text-[0.7rem] font-medium tracking-[0.16em] text-muted-foreground uppercase">Resources</div>
           <div className="flex gap-x-3">
-            {sortedResources.map(({ resourceType, quantity }) => {
+            {sortedResources.map(({ resourceType, quantity, uncommittedQuantity }) => {
               const ResourceIcon = RESOURCE_ICONS[resourceType]
               const resourceName = formatRulesetTerm(resourceType)
 
               return (
-                <div key={resourceType} className="flex items-center gap-1 text-sm font-medium" aria-label={`${quantity} ${resourceName}`}>
-                  <span>{quantity}</span>
+                <div
+                  key={resourceType}
+                  className="flex items-center gap-1 text-sm font-medium"
+                  aria-label={`${uncommittedQuantity} available of ${quantity} ${resourceName}`}
+                >
+                  <span>
+                    {uncommittedQuantity} / {quantity}
+                  </span>
                   <ResourceIcon className="size-4 text-amber-300" aria-hidden="true" />
                 </div>
               )
@@ -84,12 +102,14 @@ function ResourcesFact({ resources }: { resources: PlayerView["resources"] }): R
       </div>
       <div className="invisible absolute top-full right-0 z-20 w-full pt-2 opacity-0 transition-opacity group-hover/resources:visible group-hover/resources:opacity-100">
         <div className="grid grid-cols-[max-content_1rem_max-content] justify-start gap-x-1 gap-y-1 rounded-md border border-border/70 bg-card px-3 py-2 shadow-lg">
-          {sortedResources.map(({ resourceType, quantity }) => {
+          {sortedResources.map(({ resourceType, quantity, uncommittedQuantity }) => {
             const ResourceIcon = RESOURCE_ICONS[resourceType]
 
             return (
               <div key={resourceType} className="col-span-3 grid grid-cols-subgrid items-center text-sm font-medium">
-                <span className="text-right">{quantity}</span>
+                <span className="text-right">
+                  {uncommittedQuantity} available of {quantity}
+                </span>
                 <ResourceIcon className="size-4 text-amber-300" aria-hidden="true" />
                 <span className="text-left">{formatRulesetTerm(resourceType)}</span>
               </div>

--- a/frontend/src/features/play/components/GameTopBar.tsx
+++ b/frontend/src/features/play/components/GameTopBar.tsx
@@ -22,7 +22,7 @@ export function GameTopBar({ game, playerView }: { game: Lobby; playerView: Play
         </div>
         <div className="flex flex-wrap gap-2">
           <PlayerFact game={game} player={playerView.player} />
-          <ResourcesFact resources={playerView.resources} uncommittedResources={playerView.uncommittedResources} />
+          <ResourcesFact resources={playerView.resources} />
           <TurnFact turn={playerView.turn} />
           <NextTurnFact targetTimestamp={playerView.nextTurnAt} />
         </div>
@@ -57,20 +57,14 @@ function TurnFact({ turn }: { turn: PlayerView["turn"] }): ReactElement {
   return <TopBarFact icon={<TimerReset className="size-4" />} label="Turn" value={turn.toString()} />
 }
 
-function ResourcesFact({
-  resources,
-  uncommittedResources,
-}: {
-  resources: PlayerView["resources"]
-  uncommittedResources: PlayerView["uncommittedResources"]
-}): ReactElement {
+function ResourcesFact({ resources }: { resources: PlayerView["resources"] }): ReactElement {
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Object.entries preserves the keys of the typed resource record at runtime.
-  const resourceEntries = Object.entries(resources) as Array<[keyof typeof resources, number]>
+  const resourceEntries = Object.entries(resources) as Array<[keyof typeof resources, (typeof resources)[keyof typeof resources]]>
   const sortedResources = sortResources(
-    resourceEntries.map(([resourceType, quantity]) => ({
+    resourceEntries.map(([resourceType, { total, uncommitted }]) => ({
       resourceType,
-      quantity,
-      uncommittedQuantity: uncommittedResources[resourceType],
+      total,
+      uncommitted,
     })),
   )
 
@@ -80,7 +74,7 @@ function ResourcesFact({
         <div>
           <div className="text-[0.7rem] font-medium tracking-[0.16em] text-muted-foreground uppercase">Resources</div>
           <div className="flex gap-x-3">
-            {sortedResources.map(({ resourceType, quantity, uncommittedQuantity }) => {
+            {sortedResources.map(({ resourceType, total, uncommitted }) => {
               const ResourceIcon = RESOURCE_ICONS[resourceType]
               const resourceName = formatRulesetTerm(resourceType)
 
@@ -88,10 +82,10 @@ function ResourcesFact({
                 <div
                   key={resourceType}
                   className="flex items-center gap-1 text-sm font-medium"
-                  aria-label={`${uncommittedQuantity} available of ${quantity} ${resourceName}`}
+                  aria-label={`${uncommitted} available of ${total} ${resourceName}`}
                 >
                   <span>
-                    {uncommittedQuantity} / {quantity}
+                    {uncommitted} / {total}
                   </span>
                   <ResourceIcon className="size-4 text-amber-300" aria-hidden="true" />
                 </div>
@@ -102,13 +96,13 @@ function ResourcesFact({
       </div>
       <div className="invisible absolute top-full right-0 z-20 w-full pt-2 opacity-0 transition-opacity group-hover/resources:visible group-hover/resources:opacity-100">
         <div className="grid grid-cols-[max-content_1rem_max-content] justify-start gap-x-1 gap-y-1 rounded-md border border-border/70 bg-card px-3 py-2 shadow-lg">
-          {sortedResources.map(({ resourceType, quantity, uncommittedQuantity }) => {
+          {sortedResources.map(({ resourceType, total, uncommitted }) => {
             const ResourceIcon = RESOURCE_ICONS[resourceType]
 
             return (
               <div key={resourceType} className="col-span-3 grid grid-cols-subgrid items-center text-sm font-medium">
                 <span className="text-right">
-                  {uncommittedQuantity} available of {quantity}
+                  {uncommitted} available of {total}
                 </span>
                 <ResourceIcon className="size-4 text-amber-300" aria-hidden="true" />
                 <span className="text-left">{formatRulesetTerm(resourceType)}</span>


### PR DESCRIPTION
## Summary

- expose total and uncommitted resource stockpiles in the player view
- calculate Action affordability and cost presentation from uncommitted resources
- display available / total counts in the resource bar and document the behavior

## Testing

- pnpm checks

Part of #343