### PR TITLE
backend: persist available actions

### DIFF
--- a/backend/drizzle/0000_init.sql
+++ b/backend/drizzle/0000_init.sql
@@ -15,9 +15,8 @@ CREATE TABLE "action_submissions" (
 	"submitted_by_player_id" uuid NOT NULL,
 	"turn" integer NOT NULL,
 	"action_definition_id" text NOT NULL,
-	"targets" jsonb NOT NULL,
-	"updated_at" timestamp DEFAULT now() NOT NULL,
-	CONSTRAINT "action_submissions_game_id_player_id_turn_unique" UNIQUE("game_id","submitted_by_player_id","turn")
+	"targets" jsonb,
+	"updated_at" timestamp DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "game_states" (

--- a/backend/drizzle/0000_init.sql
+++ b/backend/drizzle/0000_init.sql
@@ -9,10 +9,10 @@ CREATE TABLE "accounts" (
 	"alias" text
 );
 --> statement-breakpoint
-CREATE TABLE "action_submissions" (
+CREATE TABLE "actions" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"game_id" integer NOT NULL,
-	"submitted_by_player_id" uuid NOT NULL,
+	"player_id" uuid NOT NULL,
 	"turn" integer NOT NULL,
 	"action_definition_id" text NOT NULL,
 	"targets" jsonb,
@@ -96,7 +96,7 @@ CREATE TABLE "turns" (
 	CONSTRAINT "turns_game_id_turn_pk" PRIMARY KEY("game_id","turn")
 );
 --> statement-breakpoint
-ALTER TABLE "action_submissions" ADD CONSTRAINT "action_submissions_gameId_playerId_game_players_fk" FOREIGN KEY ("game_id","submitted_by_player_id") REFERENCES "public"."players"("game_id","player_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "actions" ADD CONSTRAINT "actions_gameId_playerId_game_players_fk" FOREIGN KEY ("game_id","player_id") REFERENCES "public"."players"("game_id","player_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "game_states" ADD CONSTRAINT "game_states_game_id_games_id_fk" FOREIGN KEY ("game_id") REFERENCES "public"."games"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "games" ADD CONSTRAINT "games_created_by_account_id_accounts_id_fk" FOREIGN KEY ("created_by_account_id") REFERENCES "public"."accounts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "games" ADD CONSTRAINT "games_winner_account_id_accounts_id_fk" FOREIGN KEY ("winner_account_id") REFERENCES "public"."accounts"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint

--- a/backend/drizzle/meta/0000_snapshot.json
+++ b/backend/drizzle/meta/0000_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "e0815eb4-096a-4024-960a-3806699a05fb",
+  "id": "84591186-3647-4cfd-8513-a149ca7423d7",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
@@ -58,8 +58,8 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.action_submissions": {
-      "name": "action_submissions",
+    "public.actions": {
+      "name": "actions",
       "schema": "",
       "columns": {
         "id": {
@@ -75,8 +75,8 @@
           "primaryKey": false,
           "notNull": true
         },
-        "submitted_by_player_id": {
-          "name": "submitted_by_player_id",
+        "player_id": {
+          "name": "player_id",
           "type": "uuid",
           "primaryKey": false,
           "notNull": true
@@ -109,11 +109,11 @@
       },
       "indexes": {},
       "foreignKeys": {
-        "action_submissions_gameId_playerId_game_players_fk": {
-          "name": "action_submissions_gameId_playerId_game_players_fk",
-          "tableFrom": "action_submissions",
+        "actions_gameId_playerId_game_players_fk": {
+          "name": "actions_gameId_playerId_game_players_fk",
+          "tableFrom": "actions",
           "tableTo": "players",
-          "columnsFrom": ["game_id", "submitted_by_player_id"],
+          "columnsFrom": ["game_id", "player_id"],
           "columnsTo": ["game_id", "player_id"],
           "onDelete": "cascade",
           "onUpdate": "no action"

--- a/backend/drizzle/meta/0000_snapshot.json
+++ b/backend/drizzle/meta/0000_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "11bc6bfa-5b6b-4cc5-8ffa-eb342f951751",
+  "id": "e0815eb4-096a-4024-960a-3806699a05fb",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
@@ -97,7 +97,7 @@
           "name": "targets",
           "type": "jsonb",
           "primaryKey": false,
-          "notNull": true
+          "notNull": false
         },
         "updated_at": {
           "name": "updated_at",
@@ -120,13 +120,7 @@
         }
       },
       "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "action_submissions_game_id_player_id_turn_unique": {
-          "name": "action_submissions_game_id_player_id_turn_unique",
-          "nullsNotDistinct": false,
-          "columns": ["game_id", "submitted_by_player_id", "turn"]
-        }
-      },
+      "uniqueConstraints": {},
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -5,7 +5,7 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1787108293162,
+      "when": 1787520136042,
       "tag": "0000_init",
       "breakpoints": true
     }

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -5,7 +5,7 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1787520136042,
+      "when": 1787531232795,
       "tag": "0000_init",
       "breakpoints": true
     }

--- a/backend/scripts/solo-game/playSolo.ts
+++ b/backend/scripts/solo-game/playSolo.ts
@@ -257,7 +257,7 @@ function addAction(session: SoloGameSession, actionDefinitionId: string, actionS
       ...session.state.actionSubmissions,
       {
         id: `turn-${session.turn}-${actionDefinition.id}-${actionSubmissionNumber}`,
-        submittedByPlayerId: player.id,
+        playerId: player.id,
         actionDefinitionId: actionDefinition.id,
         targets: {
           self: player.id,

--- a/backend/src/api/gameplay/gameplay.controller.ts
+++ b/backend/src/api/gameplay/gameplay.controller.ts
@@ -1,5 +1,4 @@
 import { Assert, Rng, Datetime, type Logger, mulberry32Prng, Result, Timer } from "@guillaume-docquier/tools-ts"
-import { v4 } from "uuid"
 import z from "zod"
 import { type ResourceAmountsDto, ResourcesDtoSchema } from "#api/gameplay/ResourcesDto.ts"
 import { GalaxySettings } from "#api/shared/GalaxySettings.ts"
@@ -20,6 +19,7 @@ import { spiralGenerator } from "#lib/map-generation/points/spiral.generator.ts"
 import type { ActionSubmission } from "#lib/rules-engine/action-submission/ActionSubmission.ts"
 import { validateActionSubmissions } from "#lib/rules-engine/action-submission/validation/validateActionSubmissions.ts"
 import { validateCosts } from "#lib/rules-engine/action-submission/validation/validators/validateCosts.ts"
+import { computeAvailableActions } from "#lib/rules-engine/available-actions/computeAvailableActions.ts"
 import { ActionDefinitionIdSchema } from "#lib/rules-engine/ruleset-model/actions/ActionDefinition.ts"
 import { ResourceType } from "#lib/rules-engine/ruleset-model/mechanics/ResourceType.ts"
 import { RulesetSchema } from "#lib/rules-engine/ruleset-model/Ruleset.ts"
@@ -89,6 +89,10 @@ export class GameplayController {
           // Do not reuse the map generation seed, use a "secret" one, otherwise the game can be controlled by the creator
           rngState: { generatorState: UInt32.random(), spareNormal: null },
           playerResources,
+          availableActions: computeAvailableActions({
+            playerIds: gameForStart.value.playerIds,
+            ruleset: gameForStart.value.ruleset,
+          }),
           galaxy,
         },
         tx,
@@ -267,15 +271,19 @@ function toPlayerViewDto(playerViewModel: PlayerViewModel): PlayerViewDto {
     nextTurnAt: playerViewModel.nextTurnAt,
     resources: toResourcesDto(playerViewModel.resources, uncommittedResources),
     ruleset: playerViewModel.ruleset,
-    availableActions: createAvailableActions(playerViewModel, uncommittedResources),
+    availableActions: toAvailableActionDtos(playerViewModel, uncommittedResources),
   }
 }
 
 function getUncommittedResources(playerViewModel: PlayerViewModel): Record<ResourceType, number> {
   const uncommittedResources = { ...playerViewModel.resources }
 
-  for (const actionSubmission of playerViewModel.actions) {
-    const actionDefinition = playerViewModel.ruleset.actionDefinitions[actionSubmission.actionDefinitionId]
+  for (const action of playerViewModel.actions) {
+    if (action.targets === null) {
+      continue
+    }
+
+    const actionDefinition = playerViewModel.ruleset.actionDefinitions[action.actionDefinitionId]
     Assert.isDefined(actionDefinition)
 
     for (const cost of actionDefinition.costs) {
@@ -302,21 +310,17 @@ function toResourcesDto(
   }, {})
 }
 
-function createAvailableActions(
-  playerViewModel: PlayerViewModel,
-  uncommittedResources: Record<ResourceType, number>,
-): AvailableActionDto[] {
+function toAvailableActionDtos(playerViewModel: PlayerViewModel, uncommittedResources: Record<ResourceType, number>): AvailableActionDto[] {
   const turnState = createTurnState({
     playerId: playerViewModel.player.id,
     resources: uncommittedResources,
     actionSubmissions: [],
   })
 
-  return Object.values(playerViewModel.ruleset.actionDefinitions).map((actionDefinition) => {
+  return playerViewModel.actions.map((action) => {
     const availableAction = {
-      id: v4(),
-      actionDefinitionId: actionDefinition.id,
-      targets: { self: playerViewModel.player.id },
+      ...action,
+      targets: action.targets ?? { self: playerViewModel.player.id },
     }
     const actionSubmission = {
       ...availableAction,
@@ -325,7 +329,7 @@ function createAvailableActions(
     const affordabilityResult = validateCosts([actionSubmission], playerViewModel.ruleset, turnState)
     Assert.isSuccess(affordabilityResult)
 
-    return { ...availableAction, canAfford: affordabilityResult.value.length === 0 }
+    return { ...availableAction, canAfford: action.targets !== null || affordabilityResult.value.length === 0 }
   })
 }
 

--- a/backend/src/api/gameplay/gameplay.controller.ts
+++ b/backend/src/api/gameplay/gameplay.controller.ts
@@ -89,7 +89,7 @@ export class GameplayController {
           // Do not reuse the map generation seed, use a "secret" one, otherwise the game can be controlled by the creator
           rngState: { generatorState: UInt32.random(), spareNormal: null },
           playerResources,
-          availableActions: computeAvailableActions({
+          actions: computeAvailableActions({
             playerIds: gameForStart.value.playerIds,
             ruleset: gameForStart.value.ruleset,
           }),
@@ -185,7 +185,7 @@ export class GameplayController {
 
       const actionSubmission = {
         ...submittedAction,
-        submittedByPlayerId: playerId,
+        playerId,
         targets: { ...submittedAction.targets, self: playerId },
       } satisfies ActionSubmission
       const turnState = createTurnState({
@@ -321,14 +321,12 @@ function toAvailableActionDtos(playerViewModel: PlayerViewModel, uncommittedReso
     const availableAction = {
       ...action,
       targets: action.targets ?? { self: playerViewModel.player.id },
+      playerId: playerViewModel.player.id,
     }
-    const actionSubmission = {
-      ...availableAction,
-      submittedByPlayerId: playerViewModel.player.id,
-    } as const satisfies ActionSubmission
-    const affordabilityResult = validateCosts([actionSubmission], playerViewModel.ruleset, turnState)
+    const affordabilityResult = validateCosts([availableAction], playerViewModel.ruleset, turnState)
     Assert.isSuccess(affordabilityResult)
 
+    // If the action is submitted already (targets are defined), then the action is affordable because it's been committed already
     return { ...availableAction, canAfford: action.targets !== null || affordabilityResult.value.length === 0 }
   })
 }

--- a/backend/src/api/gameplay/gameplay.repository.ts
+++ b/backend/src/api/gameplay/gameplay.repository.ts
@@ -1,5 +1,5 @@
 import { type Branded, Assert, type Logger, Result, type RngState, Time, UnitOfTime, branded } from "@guillaume-docquier/tools-ts"
-import { and, eq } from "drizzle-orm"
+import { and, eq, isNotNull } from "drizzle-orm"
 import type { GameId } from "#api/shared/GameId.ts"
 import type { PlanetCoordinates } from "#api/shared/PlanetCoordinates.ts"
 import type { PlayerId } from "#api/shared/PlayerId.ts"
@@ -22,13 +22,16 @@ import {
   starsTable,
   turnsTable,
 } from "#lib/db/schema.ts"
-import { couldNot, rollbackOnFailure, TransactionRollback } from "#lib/errors.ts"
+import { couldNot, TransactionRollback } from "#lib/errors.ts"
 import type { ActionSubmission } from "#lib/rules-engine/action-submission/ActionSubmission.ts"
+import type { AvailableAction } from "#lib/rules-engine/available-actions/computeAvailableActions.ts"
+import type { ResolvedTargets } from "#lib/rules-engine/ruleset-model/actions/ResolvedTargets.ts"
 import { ResourceType } from "#lib/rules-engine/ruleset-model/mechanics/ResourceType.ts"
 import type { Ruleset } from "#lib/rules-engine/ruleset-model/Ruleset.ts"
 import { StandardRuleset } from "#lib/rulesets/standard/StandardRuleset.ts"
 
 type NewGameStateRow = typeof gameStatesTable.$inferInsert
+type NewActionSubmissionRow = typeof actionSubmissionsTable.$inferInsert
 type ActionSubmissionRow = typeof actionSubmissionsTable.$inferSelect
 type NewResourceRow = typeof resourcesTable.$inferInsert
 type ResourceRow = typeof resourcesTable.$inferSelect
@@ -73,7 +76,11 @@ export type PlayerViewModel = {
   /**
    * All the available actions, with their targets if submitted.
    */
-  readonly actions: readonly ActionSubmission[]
+  readonly actions: ReadonlyArray<{
+    readonly id: string
+    readonly actionDefinitionId: ActionSubmission["actionDefinitionId"]
+    readonly targets: ResolvedTargets | null
+  }>
   readonly ruleset: Ruleset
 }
 
@@ -108,6 +115,7 @@ export type StartGameModel = {
     readonly resourceType: ResourceType
     readonly amount: number
   }>
+  readonly availableActions: readonly AvailableAction[]
   readonly galaxy: GalaxyModel
 }
 
@@ -236,6 +244,12 @@ export class GameplayRepository extends PostgresRepository {
       ...playerResource,
       gameId: startGameModel.game.id,
     }))
+    const availableActions: NewActionSubmissionRow[] = startGameModel.availableActions.map((availableAction) => ({
+      ...availableAction,
+      gameId: startGameModel.game.id,
+      turn: gameState.turn,
+      targets: null,
+    }))
     const stars = startGameModel.galaxy.systems.map(({ star }) => ({
       gameId: startGameModel.game.id,
       ...star,
@@ -262,6 +276,9 @@ export class GameplayRepository extends PostgresRepository {
     }
     await tx.insert(gameStatesTable).values(gameState)
     await tx.insert(turnsTable).values(gameTurn)
+    if (availableActions.length > 0) {
+      await tx.insert(actionSubmissionsTable).values(availableActions)
+    }
   }
 
   public async getPlayerView(
@@ -291,9 +308,22 @@ export class GameplayRepository extends PostgresRepository {
           .from(resourcesTable)
           .where(and(eq(resourcesTable.gameId, gameId), eq(resourcesTable.playerId, playerId)))
 
-        const currentActionResult = await this.getCurrentAction({ gameId, playerId, turn: gameState.turn }, tx)
-        rollbackOnFailure(currentActionResult, "Failed to get current action")
-        const currentAction = currentActionResult.value?.actionSubmission
+        const availableActionRows = await tx
+          .select()
+          .from(actionSubmissionsTable)
+          .where(
+            and(
+              eq(actionSubmissionsTable.gameId, gameId),
+              eq(actionSubmissionsTable.submittedByPlayerId, playerId),
+              eq(actionSubmissionsTable.turn, gameState.turn),
+            ),
+          )
+          .orderBy(actionSubmissionsTable.id)
+        // ponytail: Rulesets are tiny; index persisted Actions if this becomes a measured hot path.
+        const orderedAvailableActionRows = Object.values(StandardRuleset.actionDefinitions).flatMap(({ id }) =>
+          availableActionRows.filter(({ actionDefinitionId }) => actionDefinitionId === id),
+        )
+        Assert.isTrue(orderedAvailableActionRows.length === availableActionRows.length)
 
         const stars = await tx.select().from(starsTable).where(eq(starsTable.gameId, gameId)).orderBy(starsTable.id)
         const planets = await tx.select().from(planetsTable).where(eq(planetsTable.gameId, gameId)).orderBy(planetsTable.id)
@@ -304,7 +334,11 @@ export class GameplayRepository extends PostgresRepository {
           opponents,
           galaxy: toGalaxyModel({ stars, planets }),
           resources: toResourceBag(playerResources),
-          actions: currentAction === undefined ? [] : [currentAction],
+          actions: orderedAvailableActionRows.map((row) => ({
+            id: row.id,
+            actionDefinitionId: row.actionDefinitionId,
+            targets: row.targets,
+          })),
           ruleset: StandardRuleset, // Eventually should be stored in DB
         }
       }),
@@ -334,6 +368,7 @@ export class GameplayRepository extends PostgresRepository {
             eq(actionSubmissionsTable.gameId, params.gameId),
             eq(actionSubmissionsTable.submittedByPlayerId, params.playerId),
             eq(actionSubmissionsTable.turn, params.turn),
+            isNotNull(actionSubmissionsTable.targets),
           ),
         ),
     )
@@ -408,29 +443,35 @@ export class GameplayRepository extends PostgresRepository {
         await lockGameCollectingActions({ gameId: params.gameId }, tx)
 
         const updatedAt = this.clock.now()
+        await tx
+          .update(actionSubmissionsTable)
+          .set({ targets: null, updatedAt })
+          .where(
+            and(
+              eq(actionSubmissionsTable.gameId, params.gameId),
+              eq(actionSubmissionsTable.submittedByPlayerId, params.actionSubmission.submittedByPlayerId),
+              eq(actionSubmissionsTable.turn, params.turn),
+              isNotNull(actionSubmissionsTable.targets),
+            ),
+          )
+
         const actionSubmissions = await tx
-          .insert(actionSubmissionsTable)
-          .values({
-            id: params.actionSubmission.id,
-            gameId: params.gameId,
-            turn: params.turn,
-            submittedByPlayerId: params.actionSubmission.submittedByPlayerId,
-            actionDefinitionId: params.actionSubmission.actionDefinitionId,
-            targets: params.actionSubmission.targets,
-            updatedAt,
-          })
-          .onConflictDoUpdate({
-            target: [actionSubmissionsTable.gameId, actionSubmissionsTable.submittedByPlayerId, actionSubmissionsTable.turn],
-            set: {
-              id: params.actionSubmission.id,
-              actionDefinitionId: params.actionSubmission.actionDefinitionId,
-              targets: params.actionSubmission.targets,
-              updatedAt,
-            },
-          })
+          .update(actionSubmissionsTable)
+          .set({ targets: params.actionSubmission.targets, updatedAt })
+          .where(
+            and(
+              eq(actionSubmissionsTable.id, params.actionSubmission.id),
+              eq(actionSubmissionsTable.gameId, params.gameId),
+              eq(actionSubmissionsTable.submittedByPlayerId, params.actionSubmission.submittedByPlayerId),
+              eq(actionSubmissionsTable.turn, params.turn),
+              eq(actionSubmissionsTable.actionDefinitionId, params.actionSubmission.actionDefinitionId),
+            ),
+          )
           .returning()
 
-        Assert.isTrue(actionSubmissions.length === 1)
+        if (actionSubmissions.length !== 1) {
+          throw new TransactionRollback("Action is not available for this player and Turn.")
+        }
         Assert.isDefined(actionSubmissions[0])
 
         return toActionSubmissionModel(actionSubmissions[0])
@@ -438,8 +479,8 @@ export class GameplayRepository extends PostgresRepository {
     )
 
     if (Result.isFailure(upsertResult)) {
-      this.logger.error("Could not upsert action", { ...params, error: upsertResult.error })
-      return Result.Failure(couldNot("upsert action"))
+      this.logger.error("Could not select action", { ...params, error: upsertResult.error })
+      return Result.Failure(couldNot("select action"))
     }
 
     return upsertResult
@@ -452,12 +493,13 @@ export class GameplayRepository extends PostgresRepository {
     params: { gameId: GameId; playerId: PlayerId; turn: number },
     db: PostgresRepository["db"] = this.db,
   ): Promise<Result<true, string>> {
-    const deleteResult = await Result.tryCatch(
+    const clearResult = await Result.tryCatch(
       db.transaction(async (tx) => {
         await lockGameCollectingActions({ gameId: params.gameId }, tx)
 
         await tx
-          .delete(actionSubmissionsTable)
+          .update(actionSubmissionsTable)
+          .set({ targets: null, updatedAt: this.clock.now() })
           .where(
             and(
               eq(actionSubmissionsTable.gameId, params.gameId),
@@ -468,9 +510,9 @@ export class GameplayRepository extends PostgresRepository {
       }),
     )
 
-    if (Result.isFailure(deleteResult)) {
-      this.logger.error("Could not delete action", { ...params, error: deleteResult.error })
-      return Result.Failure(couldNot("delete action"))
+    if (Result.isFailure(clearResult)) {
+      this.logger.error("Could not clear action", { ...params, error: clearResult.error })
+      return Result.Failure(couldNot("clear action"))
     }
 
     return Result.Success(true)
@@ -491,13 +533,19 @@ function toActionSubmissionModel(row: ActionSubmissionRow): ActionSubmissionMode
   return {
     gameId: row.gameId,
     turn: row.turn,
-    actionSubmission: {
-      id: row.id,
-      submittedByPlayerId: row.submittedByPlayerId,
-      actionDefinitionId: row.actionDefinitionId,
-      targets: row.targets,
-    },
+    actionSubmission: toActionSubmission(row),
     updatedAt: row.updatedAt,
+  }
+}
+
+function toActionSubmission(row: ActionSubmissionRow): ActionSubmission {
+  Assert.isDefined(row.targets)
+
+  return {
+    id: row.id,
+    submittedByPlayerId: row.submittedByPlayerId,
+    actionDefinitionId: row.actionDefinitionId,
+    targets: row.targets,
   }
 }
 

--- a/backend/src/api/gameplay/gameplay.repository.ts
+++ b/backend/src/api/gameplay/gameplay.repository.ts
@@ -13,7 +13,7 @@ import { GameStatus } from "#lib/db/lobbies/GameStatus.ts"
 import type { PlayerColor } from "#lib/db/PlayerColor.ts"
 import { PostgresRepository } from "#lib/db/PostgresRepository.ts"
 import {
-  actionSubmissionsTable,
+  actionsTable,
   gameStatesTable,
   gamesTable,
   planetsTable,
@@ -31,8 +31,8 @@ import type { Ruleset } from "#lib/rules-engine/ruleset-model/Ruleset.ts"
 import { StandardRuleset } from "#lib/rulesets/standard/StandardRuleset.ts"
 
 type NewGameStateRow = typeof gameStatesTable.$inferInsert
-type NewActionSubmissionRow = typeof actionSubmissionsTable.$inferInsert
-type ActionSubmissionRow = typeof actionSubmissionsTable.$inferSelect
+type NewActionSubmissionRow = typeof actionsTable.$inferInsert
+type ActionSubmissionRow = typeof actionsTable.$inferSelect
 type NewResourceRow = typeof resourcesTable.$inferInsert
 type ResourceRow = typeof resourcesTable.$inferSelect
 type NewTurnRow = typeof turnsTable.$inferInsert
@@ -115,7 +115,7 @@ export type StartGameModel = {
     readonly resourceType: ResourceType
     readonly amount: number
   }>
-  readonly availableActions: readonly AvailableAction[]
+  readonly actions: readonly AvailableAction[]
   readonly galaxy: GalaxyModel
 }
 
@@ -244,7 +244,7 @@ export class GameplayRepository extends PostgresRepository {
       ...playerResource,
       gameId: startGameModel.game.id,
     }))
-    const availableActions: NewActionSubmissionRow[] = startGameModel.availableActions.map((availableAction) => ({
+    const availableActions: NewActionSubmissionRow[] = startGameModel.actions.map((availableAction) => ({
       ...availableAction,
       gameId: startGameModel.game.id,
       turn: gameState.turn,
@@ -277,7 +277,7 @@ export class GameplayRepository extends PostgresRepository {
     await tx.insert(gameStatesTable).values(gameState)
     await tx.insert(turnsTable).values(gameTurn)
     if (availableActions.length > 0) {
-      await tx.insert(actionSubmissionsTable).values(availableActions)
+      await tx.insert(actionsTable).values(availableActions)
     }
   }
 
@@ -310,15 +310,9 @@ export class GameplayRepository extends PostgresRepository {
 
         const availableActionRows = await tx
           .select()
-          .from(actionSubmissionsTable)
-          .where(
-            and(
-              eq(actionSubmissionsTable.gameId, gameId),
-              eq(actionSubmissionsTable.submittedByPlayerId, playerId),
-              eq(actionSubmissionsTable.turn, gameState.turn),
-            ),
-          )
-          .orderBy(actionSubmissionsTable.id)
+          .from(actionsTable)
+          .where(and(eq(actionsTable.gameId, gameId), eq(actionsTable.playerId, playerId), eq(actionsTable.turn, gameState.turn)))
+          .orderBy(actionsTable.id)
         // ponytail: Rulesets are tiny; index persisted Actions if this becomes a measured hot path.
         const orderedAvailableActionRows = Object.values(StandardRuleset.actionDefinitions).flatMap(({ id }) =>
           availableActionRows.filter(({ actionDefinitionId }) => actionDefinitionId === id),
@@ -362,13 +356,13 @@ export class GameplayRepository extends PostgresRepository {
     const getResult = await Result.tryCatch(
       db
         .select()
-        .from(actionSubmissionsTable)
+        .from(actionsTable)
         .where(
           and(
-            eq(actionSubmissionsTable.gameId, params.gameId),
-            eq(actionSubmissionsTable.submittedByPlayerId, params.playerId),
-            eq(actionSubmissionsTable.turn, params.turn),
-            isNotNull(actionSubmissionsTable.targets),
+            eq(actionsTable.gameId, params.gameId),
+            eq(actionsTable.playerId, params.playerId),
+            eq(actionsTable.turn, params.turn),
+            isNotNull(actionsTable.targets),
           ),
         ),
     )
@@ -444,27 +438,27 @@ export class GameplayRepository extends PostgresRepository {
 
         const updatedAt = this.clock.now()
         await tx
-          .update(actionSubmissionsTable)
+          .update(actionsTable)
           .set({ targets: null, updatedAt })
           .where(
             and(
-              eq(actionSubmissionsTable.gameId, params.gameId),
-              eq(actionSubmissionsTable.submittedByPlayerId, params.actionSubmission.submittedByPlayerId),
-              eq(actionSubmissionsTable.turn, params.turn),
-              isNotNull(actionSubmissionsTable.targets),
+              eq(actionsTable.gameId, params.gameId),
+              eq(actionsTable.playerId, params.actionSubmission.playerId),
+              eq(actionsTable.turn, params.turn),
+              isNotNull(actionsTable.targets),
             ),
           )
 
         const actionSubmissions = await tx
-          .update(actionSubmissionsTable)
+          .update(actionsTable)
           .set({ targets: params.actionSubmission.targets, updatedAt })
           .where(
             and(
-              eq(actionSubmissionsTable.id, params.actionSubmission.id),
-              eq(actionSubmissionsTable.gameId, params.gameId),
-              eq(actionSubmissionsTable.submittedByPlayerId, params.actionSubmission.submittedByPlayerId),
-              eq(actionSubmissionsTable.turn, params.turn),
-              eq(actionSubmissionsTable.actionDefinitionId, params.actionSubmission.actionDefinitionId),
+              eq(actionsTable.id, params.actionSubmission.id),
+              eq(actionsTable.gameId, params.gameId),
+              eq(actionsTable.playerId, params.actionSubmission.playerId),
+              eq(actionsTable.turn, params.turn),
+              eq(actionsTable.actionDefinitionId, params.actionSubmission.actionDefinitionId),
             ),
           )
           .returning()
@@ -498,14 +492,10 @@ export class GameplayRepository extends PostgresRepository {
         await lockGameCollectingActions({ gameId: params.gameId }, tx)
 
         await tx
-          .update(actionSubmissionsTable)
+          .update(actionsTable)
           .set({ targets: null, updatedAt: this.clock.now() })
           .where(
-            and(
-              eq(actionSubmissionsTable.gameId, params.gameId),
-              eq(actionSubmissionsTable.submittedByPlayerId, params.playerId),
-              eq(actionSubmissionsTable.turn, params.turn),
-            ),
+            and(eq(actionsTable.gameId, params.gameId), eq(actionsTable.playerId, params.playerId), eq(actionsTable.turn, params.turn)),
           )
       }),
     )
@@ -543,7 +533,7 @@ function toActionSubmission(row: ActionSubmissionRow): ActionSubmission {
 
   return {
     id: row.id,
-    submittedByPlayerId: row.submittedByPlayerId,
+    playerId: row.playerId,
     actionDefinitionId: row.actionDefinitionId,
     targets: row.targets,
   }

--- a/backend/src/api/gameplay/gameplay.router.test.ts
+++ b/backend/src/api/gameplay/gameplay.router.test.ts
@@ -154,6 +154,7 @@ describe("gameplay.router", () => {
 
       // Act
       const getByIdResult = await player.client.gameplay.getPlayerView.query({ gameId: createdGameId })
+      const repeatedGetByIdResult = await player.client.gameplay.getPlayerView.query({ gameId: createdGameId })
 
       // Assert
       expect(getByIdResult).toEqual<typeof getByIdResult>({
@@ -205,6 +206,7 @@ describe("gameplay.router", () => {
           },
         ],
       })
+      expect(repeatedGetByIdResult.availableActions).toEqual(getByIdResult.availableActions)
     })
 
     it("should expose uncommitted resources and use them to determine Action affordability", async () => {
@@ -215,29 +217,32 @@ describe("gameplay.router", () => {
       await player.client.gameplay.startGame.mutate({ gameId: createdGameId })
 
       const initialPlayerView = await player.client.gameplay.getPlayerView.query({ gameId: createdGameId })
-      const extractMetal = initialPlayerView.availableActions.find(({ actionDefinitionId }) => actionDefinitionId === GainMetal.id)
-      Assert.isDefined(extractMetal)
+      const generatePower = initialPlayerView.availableActions.find(({ actionDefinitionId }) => actionDefinitionId === GainEnergy.id)
+      Assert.isDefined(generatePower)
 
       await player.client.gameplay.setCurrentAction.mutate({
         gameId: createdGameId,
         turn: initialPlayerView.turn,
-        actionSubmission: extractMetal,
+        actionSubmission: generatePower,
       })
 
       // Act
       const playerView = await player.client.gameplay.getPlayerView.query({ gameId: createdGameId })
-      const generatePower = playerView.availableActions.find(({ actionDefinitionId }) => actionDefinitionId === GainEnergy.id)
-      Assert.isDefined(generatePower)
+      const selectedGeneratePower = playerView.availableActions.find(({ actionDefinitionId }) => actionDefinitionId === GainEnergy.id)
+      const extractMetal = playerView.availableActions.find(({ actionDefinitionId }) => actionDefinitionId === GainMetal.id)
+      Assert.isDefined(selectedGeneratePower)
+      Assert.isDefined(extractMetal)
 
       // Assert
       expect(playerView.resources).toEqual<typeof playerView.resources>(
         createResourcesDtoStub({
-          [ResourceType.INFLUENCE]: { uncommitted: 2, total: 3 },
+          [ResourceType.INFLUENCE]: { uncommitted: 0, total: 3 },
           [ResourceType.METAL]: { uncommitted: 2, total: 2 },
-          [ResourceType.FUEL]: { uncommitted: 1, total: 1 },
+          [ResourceType.FUEL]: { uncommitted: 0, total: 1 },
         }),
       )
-      expect(generatePower.canAfford).toBe(false)
+      expect(selectedGeneratePower.canAfford).toBe(true)
+      expect(extractMetal.canAfford).toBe(false)
     })
 
     it("should expose the current player and every opponent with their colors", async () => {
@@ -365,6 +370,27 @@ describe("gameplay.router", () => {
         gameId: createdGameId,
         turn: 0,
         actionSubmission: winTheGame,
+      })
+
+      // Assert
+      await expect(setActionPromise).rejects.toMatchObject({ data: { code: "BAD_REQUEST" } })
+    })
+
+    it("should reject an action that is not available to the player", async () => {
+      // Arrange
+      using apiServer = new ApiServer(await createApiStub())
+      const player = await apiServer.createClient({ authenticated: true })
+      const { createdGameId } = await player.client.lobbies.create.mutate({ configuration: createGameConfigurationDtoStub() })
+      await player.client.gameplay.startGame.mutate({ gameId: createdGameId })
+      const playerView = await player.client.gameplay.getPlayerView.query({ gameId: createdGameId })
+      const makeMoreMoney = playerView.availableActions.find(({ actionDefinitionId }) => actionDefinitionId === GainInfluence.id)
+      Assert.isDefined(makeMoreMoney)
+
+      // Act
+      const setActionPromise = player.client.gameplay.setCurrentAction.mutate({
+        gameId: createdGameId,
+        turn: 0,
+        actionSubmission: { ...makeMoreMoney, id: "unavailable-action" },
       })
 
       // Assert

--- a/backend/src/lib/db/schema.ts
+++ b/backend/src/lib/db/schema.ts
@@ -151,12 +151,12 @@ export const gameStatesTable = pgTable("game_states", {
  * Actions available for a specific game turn.
  * Rows are kept as append-only history across turns.
  */
-export const actionSubmissionsTable = pgTable(
-  "action_submissions",
+export const actionsTable = pgTable(
+  "actions",
   {
     id: uuid("id").primaryKey().defaultRandom(),
     gameId: gameId("game_id").notNull(),
-    submittedByPlayerId: playerId("submitted_by_player_id").notNull(),
+    playerId: playerId("player_id").notNull(),
     turn: integer("turn").notNull(),
     actionDefinitionId: text("action_definition_id").notNull(),
     targets: jsonb("targets").$type<ResolvedTargets>(),
@@ -164,9 +164,9 @@ export const actionSubmissionsTable = pgTable(
   },
   (table) => [
     foreignKey({
-      columns: [table.gameId, table.submittedByPlayerId],
+      columns: [table.gameId, table.playerId],
       foreignColumns: [playersTable.gameId, playersTable.playerId],
-      name: "action_submissions_gameId_playerId_game_players_fk",
+      name: "actions_gameId_playerId_game_players_fk",
     }).onDelete("cascade"),
   ],
 )

--- a/backend/src/lib/db/schema.ts
+++ b/backend/src/lib/db/schema.ts
@@ -148,7 +148,7 @@ export const gameStatesTable = pgTable("game_states", {
 })
 
 /**
- * Actions submitted for a specific game turn.
+ * Actions available for a specific game turn.
  * Rows are kept as append-only history across turns.
  */
 export const actionSubmissionsTable = pgTable(
@@ -159,11 +159,10 @@ export const actionSubmissionsTable = pgTable(
     submittedByPlayerId: playerId("submitted_by_player_id").notNull(),
     turn: integer("turn").notNull(),
     actionDefinitionId: text("action_definition_id").notNull(),
-    targets: jsonb("targets").$type<ResolvedTargets>().notNull(),
+    targets: jsonb("targets").$type<ResolvedTargets>(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
   (table) => [
-    unique("action_submissions_game_id_player_id_turn_unique").on(table.gameId, table.submittedByPlayerId, table.turn),
     foreignKey({
       columns: [table.gameId, table.submittedByPlayerId],
       foreignColumns: [playersTable.gameId, playersTable.playerId],

--- a/backend/src/lib/rules-engine/action-submission/ActionSubmission.stub.ts
+++ b/backend/src/lib/rules-engine/action-submission/ActionSubmission.stub.ts
@@ -2,14 +2,14 @@ import { v4 } from "uuid"
 import type { ActionSubmission } from "#lib/rules-engine/action-submission/ActionSubmission.ts"
 
 export function createActionSubmissionStub(overrides?: Partial<ActionSubmission>): ActionSubmission {
-  const submittedByPlayerId = v4()
+  const playerId = v4()
 
   return {
     id: v4(),
-    submittedByPlayerId,
+    playerId,
     actionDefinitionId: v4(),
     targets: {
-      self: submittedByPlayerId,
+      self: playerId,
     },
     ...overrides,
   }

--- a/backend/src/lib/rules-engine/action-submission/ActionSubmission.ts
+++ b/backend/src/lib/rules-engine/action-submission/ActionSubmission.ts
@@ -7,7 +7,7 @@ import type { ResolvedTargets } from "#lib/rules-engine/ruleset-model/actions/Re
  */
 export type ActionSubmission = Readonly<{
   id: string
-  submittedByPlayerId: PlayerId
+  playerId: PlayerId
   actionDefinitionId: ActionDefinition["id"]
   /**
    * Contains the targets to fill required by the ActionDefinition.

--- a/backend/src/lib/rules-engine/available-actions/computeAvailableActions.ts
+++ b/backend/src/lib/rules-engine/available-actions/computeAvailableActions.ts
@@ -1,0 +1,23 @@
+import type { PlayerId } from "#api/shared/PlayerId.ts"
+import type { ActionDefinition } from "#lib/rules-engine/ruleset-model/actions/ActionDefinition.ts"
+import type { Ruleset } from "#lib/rules-engine/ruleset-model/Ruleset.ts"
+
+/**
+ * An Action Definition offered to one player for a Turn.
+ */
+export type AvailableAction = Readonly<{
+  submittedByPlayerId: PlayerId
+  actionDefinitionId: ActionDefinition["id"]
+}>
+
+/**
+ * Computes the Action instances available to every player for a Turn.
+ */
+export function computeAvailableActions({ playerIds, ruleset }: { playerIds: readonly PlayerId[]; ruleset: Ruleset }): AvailableAction[] {
+  return playerIds.flatMap((submittedByPlayerId) =>
+    Object.values(ruleset.actionDefinitions).map(({ id: actionDefinitionId }) => ({
+      submittedByPlayerId,
+      actionDefinitionId,
+    })),
+  )
+}

--- a/backend/src/lib/rules-engine/available-actions/computeAvailableActions.ts
+++ b/backend/src/lib/rules-engine/available-actions/computeAvailableActions.ts
@@ -6,7 +6,7 @@ import type { Ruleset } from "#lib/rules-engine/ruleset-model/Ruleset.ts"
  * An Action Definition offered to one player for a Turn.
  */
 export type AvailableAction = Readonly<{
-  submittedByPlayerId: PlayerId
+  playerId: PlayerId
   actionDefinitionId: ActionDefinition["id"]
 }>
 
@@ -14,9 +14,9 @@ export type AvailableAction = Readonly<{
  * Computes the Action instances available to every player for a Turn.
  */
 export function computeAvailableActions({ playerIds, ruleset }: { playerIds: readonly PlayerId[]; ruleset: Ruleset }): AvailableAction[] {
-  return playerIds.flatMap((submittedByPlayerId) =>
+  return playerIds.flatMap((playerId) =>
     Object.values(ruleset.actionDefinitions).map(({ id: actionDefinitionId }) => ({
-      submittedByPlayerId,
+      playerId,
       actionDefinitionId,
     })),
   )

--- a/backend/src/turn-processing/TurnProcessor.test.ts
+++ b/backend/src/turn-processing/TurnProcessor.test.ts
@@ -137,6 +137,7 @@ describe("TurnProcessor", () => {
 
       // Assert
       const playerView = await player.client.gameplay.getPlayerView.query({ gameId: createdGameId })
+      const repeatedPlayerView = await player.client.gameplay.getPlayerView.query({ gameId: createdGameId })
       expect(playerView).toEqual<typeof playerView>({
         ...initialPlayerView,
         turn: 1,
@@ -148,6 +149,8 @@ describe("TurnProcessor", () => {
         }),
         availableActions: expect.any(Array),
       })
+      expect(playerView.availableActions.map(({ id }) => id)).not.toEqual(initialPlayerView.availableActions.map(({ id }) => id))
+      expect(repeatedPlayerView.availableActions).toEqual(playerView.availableActions)
     })
 
     it.each([
@@ -476,6 +479,7 @@ describe("TurnProcessor", () => {
           [ResourceType.INFLUENCE]: { total: 3, uncommitted: 3 },
         },
       })
+      expect(creatorView.availableActions).toHaveLength(5)
 
       const joinerView = await joiner.client.gameplay.getPlayerView.query({ gameId: createdGameId })
       expect(joinerView).toMatchObject({

--- a/backend/src/turn-processing/TurnProcessor.ts
+++ b/backend/src/turn-processing/TurnProcessor.ts
@@ -3,6 +3,7 @@ import type { Clock } from "#lib/Clock.ts"
 import type { CreateTransaction } from "#lib/db/createDb.ts"
 import { GameStatus } from "#lib/db/lobbies/GameStatus.ts"
 import { rollbackOnFailure, TransactionRollback } from "#lib/errors.ts"
+import { computeAvailableActions } from "#lib/rules-engine/available-actions/computeAvailableActions.ts"
 import { ResourceType } from "#lib/rules-engine/ruleset-model/mechanics/ResourceType.ts"
 import { resolveTurn } from "#lib/rules-engine/turn-resolution/resolveTurn.ts"
 import type { ResolveTurnError } from "#lib/rules-engine/turn-resolution/ResolveTurnError.ts"
@@ -142,6 +143,10 @@ export class TurnProcessor {
       gameId: turnToProcess.gameId,
       turn: turnToProcess.turn,
       nextTurn: turnToProcess.turn + 1,
+      availableActions: computeAvailableActions({
+        playerIds: Object.values(resolvedTurnResult.value.players).map(({ id }) => id),
+        ruleset: turnToProcess.ruleset,
+      }),
       processedAt,
       rngState: rng.getState(),
       playerResources: Object.values(resolvedTurnResult.value.players).flatMap((player) =>

--- a/backend/src/turn-processing/turns.repository.ts
+++ b/backend/src/turn-processing/turns.repository.ts
@@ -7,7 +7,7 @@ import type { AccountId } from "#lib/db/accounts/AccountId.ts"
 import type { Transaction } from "#lib/db/createDb.ts"
 import { GameStatus } from "#lib/db/lobbies/GameStatus.ts"
 import { PostgresRepository } from "#lib/db/PostgresRepository.ts"
-import { actionSubmissionsTable, gameStatesTable, gamesTable, playersTable, resourcesTable, turnsTable } from "#lib/db/schema.ts"
+import { actionsTable, gameStatesTable, gamesTable, playersTable, resourcesTable, turnsTable } from "#lib/db/schema.ts"
 import { couldNot } from "#lib/errors.ts"
 import type { ActionSubmission } from "#lib/rules-engine/action-submission/ActionSubmission.ts"
 import type { AvailableAction } from "#lib/rules-engine/available-actions/computeAvailableActions.ts"
@@ -17,7 +17,7 @@ import { StandardRuleset } from "#lib/rulesets/standard/StandardRuleset.ts"
 
 type PlayerRow = typeof playersTable.$inferSelect
 type ResourceRow = typeof resourcesTable.$inferSelect
-type ActionSubmissionRow = typeof actionSubmissionsTable.$inferSelect
+type ActionSubmissionRow = typeof actionsTable.$inferSelect
 
 /**
  * Owning a TurnForProcessing within a transaction guarantees that the turn and the game are locked, exist and need processing at this time.
@@ -183,14 +183,11 @@ export class TurnsRepository extends PostgresRepository {
           .orderBy(asc(resourcesTable.playerId), asc(resourcesTable.resourceType)),
         tx
           .select()
-          .from(actionSubmissionsTable)
+          .from(actionsTable)
           .where(
-            and(
-              eq(actionSubmissionsTable.gameId, startTurnProcessingModel.turn.gameId),
-              eq(actionSubmissionsTable.turn, startTurnProcessingModel.turn.turn),
-            ),
+            and(eq(actionsTable.gameId, startTurnProcessingModel.turn.gameId), eq(actionsTable.turn, startTurnProcessingModel.turn.turn)),
           )
-          .orderBy(asc(actionSubmissionsTable.submittedByPlayerId)),
+          .orderBy(asc(actionsTable.playerId)),
       ])
       Assert.isTrue(gameStates.length === 1)
       Assert.isDefined(gameStates[0])
@@ -306,7 +303,7 @@ export class TurnsRepository extends PostgresRepository {
           targets: null,
         }))
         if (availableActions.length > 0) {
-          await tx.insert(actionSubmissionsTable).values(availableActions)
+          await tx.insert(actionsTable).values(availableActions)
         }
 
         const updatedGameStates = await tx
@@ -356,8 +353,8 @@ function toTurnToProcessModel({
     scheduledFor,
     turnInterval,
     rngState,
-    actionSubmissions: actionSubmissions.flatMap(({ id, submittedByPlayerId, actionDefinitionId, targets }) =>
-      targets === null ? [] : [{ id, submittedByPlayerId, actionDefinitionId, targets }],
+    actionSubmissions: actionSubmissions.flatMap(({ id, playerId, actionDefinitionId, targets }) =>
+      targets === null ? [] : [{ id, playerId, actionDefinitionId, targets }],
     ),
     players: players.reduce<TurnToProcessModel["players"]>((playersById, { playerId }) => {
       const resourcesForPlayer = resourcesByPlayerId.get(playerId)

--- a/backend/src/turn-processing/turns.repository.ts
+++ b/backend/src/turn-processing/turns.repository.ts
@@ -10,6 +10,7 @@ import { PostgresRepository } from "#lib/db/PostgresRepository.ts"
 import { actionSubmissionsTable, gameStatesTable, gamesTable, playersTable, resourcesTable, turnsTable } from "#lib/db/schema.ts"
 import { couldNot } from "#lib/errors.ts"
 import type { ActionSubmission } from "#lib/rules-engine/action-submission/ActionSubmission.ts"
+import type { AvailableAction } from "#lib/rules-engine/available-actions/computeAvailableActions.ts"
 import type { ResourceType } from "#lib/rules-engine/ruleset-model/mechanics/ResourceType.ts"
 import type { Ruleset } from "#lib/rules-engine/ruleset-model/Ruleset.ts"
 import { StandardRuleset } from "#lib/rulesets/standard/StandardRuleset.ts"
@@ -69,6 +70,7 @@ export type ProcessedTurnModel = {
   gameStatus: GameStatus // We could discriminate on gameStatus, but in the current shape of things it makes the code a lot more complicated
   winnerAccountId?: AccountId
   nextTurn: number
+  availableActions: AvailableAction[]
   /**
    * Not defined when endedAt is set
    */
@@ -297,6 +299,16 @@ export class TurnsRepository extends PostgresRepository {
           Assert.isTrue(insertedTurns.length === 1)
         }
 
+        const availableActions = processedTurnModel.availableActions.map((availableAction) => ({
+          ...availableAction,
+          gameId: processedTurnModel.gameId,
+          turn: processedTurnModel.nextTurn,
+          targets: null,
+        }))
+        if (availableActions.length > 0) {
+          await tx.insert(actionSubmissionsTable).values(availableActions)
+        }
+
         const updatedGameStates = await tx
           .update(gameStatesTable)
           .set({
@@ -344,12 +356,9 @@ function toTurnToProcessModel({
     scheduledFor,
     turnInterval,
     rngState,
-    actionSubmissions: actionSubmissions.map(({ id, submittedByPlayerId, actionDefinitionId, targets }) => ({
-      id,
-      submittedByPlayerId,
-      actionDefinitionId,
-      targets,
-    })),
+    actionSubmissions: actionSubmissions.flatMap(({ id, submittedByPlayerId, actionDefinitionId, targets }) =>
+      targets === null ? [] : [{ id, submittedByPlayerId, actionDefinitionId, targets }],
+    ),
     players: players.reduce<TurnToProcessModel["players"]>((playersById, { playerId }) => {
       const resourcesForPlayer = resourcesByPlayerId.get(playerId)
       Assert.isDefined(resourcesForPlayer)

--- a/frontend/playwright/specs/lobbies.spec.ts
+++ b/frontend/playwright/specs/lobbies.spec.ts
@@ -187,17 +187,20 @@ test.describe("authenticated user", () => {
       await expect(winTheGame).toHaveAttribute("aria-disabled", "true")
       await expect(winTheGame.locator("[data-unaffordable-overlay]")).toBeVisible()
       await expect(winTheGame.locator('[aria-label="10 Influence, cannot afford"]')).toHaveClass(/text-red-400/)
-      await expect(winTheGame).not.toContainText("Unavailable")
 
-      await actionsPage.toggleAction("Extract Metal")
-      await expect(extractMetal).toHaveAttribute("aria-pressed", "true")
-      await expect(actionsPage.resource("Influence")).toHaveAttribute("aria-label", "2 available of 3 Influence")
-      await expect(actionsPage.action("Generate Power")).toHaveAttribute("aria-disabled", "true")
-    })
+      const generatePower = actionsPage.action("Generate Power")
+      await actionsPage.toggleAction("Generate Power")
+      await expect(generatePower).toHaveAttribute("aria-pressed", "true")
+      await expect(generatePower).toHaveAttribute("aria-disabled", "false")
+      await expect(generatePower.locator("[data-unaffordable-overlay]")).not.toBeVisible()
+      await expect(generatePower.locator('[aria-label="3 Influence"]')).not.toHaveClass(/text-red-400/)
+      await expect(generatePower.locator('[aria-label="1 Fuel"]')).not.toHaveClass(/text-red-400/)
 
-    await test.step("Deselect the Action and release its resources", async () => {
-      await actionsPage.toggleAction("Extract Metal")
-      await expect(actionsPage.action("Extract Metal")).toHaveAttribute("aria-pressed", "false")
+      await expect(actionsPage.resource("Influence")).toHaveAttribute("aria-label", "0 available of 3 Influence")
+      await expect(extractMetal).toHaveAttribute("aria-disabled", "true")
+
+      await actionsPage.toggleAction("Generate Power")
+      await expect(generatePower).toHaveAttribute("aria-pressed", "false")
       await expect(actionsPage.resource("Influence")).toHaveAttribute("aria-label", "3 available of 3 Influence")
     })
 

--- a/frontend/src/features/play/components/ActionCard.tsx
+++ b/frontend/src/features/play/components/ActionCard.tsx
@@ -112,7 +112,7 @@ export function ActionCard({
               {formatRulesetTerm(actionDefinition.tier)} {formatRulesetTerm(actionDefinition.type)}
             </CardDescription>
           </div>
-          <ActionCosts costs={actionDefinition.costs} resources={resources} />
+          <ActionCosts costs={actionDefinition.costs} resources={resources} canAfford={canAfford} />
         </div>
       </CardHeader>
       <CardContent className="relative z-10 flex min-h-36 flex-1 flex-col gap-4 border-t border-border/70 px-5 py-5">
@@ -124,14 +124,22 @@ export function ActionCard({
   )
 }
 
-function ActionCosts({ costs, resources }: { costs: ActionDefinition["costs"]; resources: PlayerView["resources"] }): ReactElement {
+function ActionCosts({
+  costs,
+  resources,
+  canAfford,
+}: {
+  costs: ActionDefinition["costs"]
+  resources: PlayerView["resources"]
+  canAfford: boolean
+}): ReactElement {
   const costsByResource = Map.groupBy(sortResources(costs), ({ resourceType }) => resourceType)
 
   return (
     <div className="flex flex-col items-end gap-1" aria-label="Costs">
       {[...costsByResource].map(([resourceType, resourceCosts]) => {
         const quantity = resourceCosts.reduce((total, cost) => total + cost.quantity, 0)
-        const cannotAfford = quantity > resources[resourceType].uncommitted
+        const cannotAfford = !canAfford && quantity > resources[resourceType].uncommitted
         const ResourceIcon = RESOURCE_ICONS[resourceType]
         return (
           <div


### PR DESCRIPTION
## Summary

- compute and persist each player's fixed available Actions at game start and after successful Turn Resolution
- use nullable targets to distinguish available Actions from selected Action Submissions
- return stable per-Turn Action ids and reject ids outside the persisted pool
- add the generated Drizzle migration and integration coverage

## Verification
- pnpm --filter backend checks
- pnpm lint
- pnpm format

part of #343

requires a db wipe